### PR TITLE
Fix Production Playground Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "build": "NODE_ENV=production ./scripts/build.sh",
-    "start": "node dist/index.js",
+    "start": "NODE_ENV=production node dist/index.js",
     "dev": "ts-node-dev src/index.ts",
-    "prod": "NODE_ENV=production npm run db:start:prod && npm run db:setup && npm run start",
+    "prod": "npm run db:start:prod && npm run db:setup && npm run start",
     "test": "jest",
     "contracts:start-blockchain-client": "cd lib/colonyNetwork && yarn start:blockchain:client",
     "contracts:migrate": "cd lib/colonyNetwork && yarn truffle migrate",

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -86,6 +86,5 @@ export const createApolloServer = (db: Db, provider: Provider) => {
         userAddress,
       }
     },
-    playground: isDevelopment,
   })
 }

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -11,7 +11,6 @@ import { ColonyMongoApi } from '../db/colonyMongoApi'
 import { ColonyMongoDataSource } from '../db/colonyMongoDataSource'
 import { ColonyAuthDataSource } from '../network/colonyAuthDataSource'
 import { resolvers } from './resolvers'
-import { isDevelopment } from '../env';
 
 import Colony from './typeDefs/Colony'
 import Domain from './typeDefs/Domain'


### PR DESCRIPTION
This PR fixes the way we start the compiled version of server _(ie: passing `NODE_ENV=production`)_ as to signal to `node` that we need to run in production mode.

This is valuable since it will also tell graphQL to disable the playground and introspection while we're running this in production.