### PR TITLE
DB setup script only create collection if it doesn't exist

### DIFF
--- a/scripts/db-setup.ts
+++ b/scripts/db-setup.ts
@@ -11,20 +11,20 @@ const createCollections = async (db: Db) => {
   return Promise.all(
     Array.from(COLLECTIONS_MANIFEST.entries()).map(
       async ([name, { create, indexes, seedDocs = [] }]) => {
-        if (!collections.map(c => c.collectionName).includes(name)) {
-          console.info(`Creating collection ${name}`)
-          await db.createCollection(name, create)
+        console.info(`Creating collection ${name}`)
+        await db.createCollection(name, create)
 
-          await Promise.all(
-            indexes.map(([fieldName, options]) =>
-              db.createIndex(name, fieldName, options),
-            ),
-          )
-          if (seedDocs.length) {
-            await db.collection(name).insertMany(seedDocs)
-          }
-        } else {
-          console.info(`Skip creating collection ${name}, as it already exists`);
+        await Promise.all(
+          indexes.map(([fieldName, options]) =>
+            db.createIndex(name, fieldName, options),
+          ),
+        )
+        if (collections.map(c => c.collectionName).includes(name)) {
+          console.log(`${name} collection already exists, don't seed it again`);
+          return;
+        }
+        if (seedDocs.length) {
+          await db.collection(name).insertMany(seedDocs)
         }
       },
     ),


### PR DESCRIPTION
This PR adds a check in the `db-setup` script that only creates the collection if it doesn't already exist.

This is needed in order to restore the database and not have it overwritten / re-created when the docker container is restarted.
