### PR TITLE
Return minimal user from assignedWorker resolver

### DIFF
--- a/src/db/colonyMongoDataSource.ts
+++ b/src/db/colonyMongoDataSource.ts
@@ -105,6 +105,23 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
     }
   }
 
+  // Get a minimal user profile for unregistered users
+  static getMinimalUser(address): User {
+    return {
+      id: address,
+      createdAt: new Date(0),
+      colonies: [],
+      notifications: [],
+      tasks: [],
+      colonyAddresses: [],
+      tokenAddresses: [],
+      taskIds: [],
+      profile: {
+        walletAddress: address,
+      }
+    }
+  }
+
   private static transformEvent<C extends object>({
     _id,
     context,

--- a/src/graphql/resolvers/Task.ts
+++ b/src/graphql/resolvers/Task.ts
@@ -1,5 +1,6 @@
 import { ApolloContext } from '../apolloTypes'
 import { TaskResolvers, TaskPayoutResolvers } from '../types'
+import { ColonyMongoDataSource } from '../../db/colonyMongoDataSource'
 
 export const Task: TaskResolvers<ApolloContext> = {
   async colony({ colonyAddress }, input, { dataSources: { data } }) {
@@ -20,9 +21,14 @@ export const Task: TaskResolvers<ApolloContext> = {
     input,
     { dataSources: { data } },
   ) {
-    return assignedWorkerAddress
-      ? await data.getUserByAddress(assignedWorkerAddress)
-      : null
+    if (assignedWorkerAddress) {
+      try {
+        return await data.getUserByAddress(assignedWorkerAddress)
+      } catch (err) {
+        return ColonyMongoDataSource.getMinimalUser(assignedWorkerAddress)
+      }
+    }
+    return null
   },
   async workInvites({ workInviteAddresses }, input, { dataSources: { data } }) {
     return data.getUsersByAddress(workInviteAddresses)


### PR DESCRIPTION
This PR returns a minimal user profile when an assigned worker is not registered with colony yet. That dapp should gracefully handle that and only show the address of that user.

Resolves JoinColony/colonyDapp#1996