### PR TITLE
Handle Remove Task Due Date Event

### DIFF
--- a/src/graphql/typeDefs/Event.ts
+++ b/src/graphql/typeDefs/Event.ts
@@ -89,7 +89,7 @@ export default gql`
   type SetTaskDueDateEvent implements TaskEvent {
     type: EventType!
     taskId: String!
-    dueDate: GraphQLDateTime!
+    dueDate: GraphQLDateTime
     colonyAddress: String
   }
 

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -863,7 +863,7 @@ export type SetTaskDueDateEvent = TaskEvent & {
    __typename?: 'SetTaskDueDateEvent',
   type: EventType,
   taskId: Scalars['String'],
-  dueDate: Scalars['GraphQLDateTime'],
+  dueDate?: Maybe<Scalars['GraphQLDateTime']>,
   colonyAddress?: Maybe<Scalars['String']>,
 };
 
@@ -1654,7 +1654,7 @@ export type SetTaskDomainEventResolvers<ContextType = any, ParentType extends Re
 export type SetTaskDueDateEventResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetTaskDueDateEvent'] = ResolversParentTypes['SetTaskDueDateEvent']> = {
   type?: Resolver<ResolversTypes['EventType'], ParentType, ContextType>,
   taskId?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-  dueDate?: Resolver<ResolversTypes['GraphQLDateTime'], ParentType, ContextType>,
+  dueDate?: Resolver<Maybe<ResolversTypes['GraphQLDateTime']>, ParentType, ContextType>,
   colonyAddress?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
 };
 


### PR DESCRIPTION
This PR remove the requirement _(`!`)_ for the `dueDate` value to be present in the query of the `SetTaskDueDate` event.

This is because this mutations covers both cases: setting the task due date, or removing it.

If a value is provided for the due date, it will be set (or re-set), but if one if omitted, then the value will be `$unset` in the database.

See more here:
https://github.com/JoinColony/colonyServer/blob/693a495fed7d3cdacad5f1b1123555fc11b264a6/src/db/colonyMongoApi.ts#L533-L540

All in all, the task's due date setting/un-setting logic worked already, it's just the task events feed that was broken.

Contributes to JoinColony/colonyDapp#2099