### PR TITLE
Remove SetTaskPending user notification

### DIFF
--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -858,8 +858,6 @@ export class ColonyMongoApi {
         txHash,
       },
     )
-    await this.createTaskNotification(initiator, eventId, taskId)
-
     return this.updateTask(taskId, {}, { $set: { txHash } })
   }
 


### PR DESCRIPTION
Just a little fix to remove the `SetTaskPending` notification that should not be shown to users.