### PR TITLE
Only notify assigned / unassigned users of a task of the event

### DIFF
--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -270,13 +270,6 @@ export class ColonyMongoApi {
     )
   }
 
-  private async createSpecificTaskNotification(
-    notifiedUserAddress: string,
-    eventId: ObjectID,
-  ) {
-    return this.createNotification(eventId, [notifiedUserAddress])
-  }
-
   private async createColonyNotification(
     initiator: string,
     eventId: ObjectID,
@@ -810,7 +803,7 @@ export class ColonyMongoApi {
       workerAddress,
       colonyAddress,
     })
-    await this.createSpecificTaskNotification(workerAddress, eventId)
+    await this.createNotification(eventId, [workerAddress])
     return this.updateTask(
       taskId,
       {},
@@ -843,7 +836,7 @@ export class ColonyMongoApi {
         colonyAddress,
       },
     )
-    await this.createSpecificTaskNotification(workerAddress, eventId)
+    await this.createNotification(eventId, [workerAddress])
     return this.updateTask(
       taskId,
       { assignedWorkerAddress: workerAddress },


### PR DESCRIPTION
This PR fixes a (not necessarily a issue) interaction where for all the events changed on a task, all subscribed users of task get notified.

This is actually pretty good logic, except that this should not apply for assign / unassign worker events, which are inherently singular.

Another issue that was fixed here is that, if a worker is assigned to a task, without prior knowledge of that task (ie: is not subscribed to it), it will not have gotten notified that the task was assigned to him.

### Changes

- [x] `colonyMongoApi` `assignWorker` attept to subscribe the worker to the task as well
- [x] `colonyMongoApi` created a `createSpecificTaskNotification` private method
- [x] `colonyMongoApi` `assignWorker` and `unassignWorker` only notify the specific worker of this event
- [x] `colonyMongoApi` removed unused imports 

Resolves JoinColony/colonyDapp#2120