### PR TITLE
Event Monitor Proof of Concept

### DIFF
--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -1,6 +1,7 @@
 import { CollectionCreateOptions, IndexOptions } from 'mongodb'
 import {
   ColonyDoc,
+  ChainEventDoc,
   DomainDoc,
   EventDoc,
   LevelDoc,
@@ -17,6 +18,7 @@ import { ETH_ADDRESS } from '../constants'
 
 export enum CollectionNames {
   Colonies = 'colonies',
+  ChainEvents = 'chainEvents',
   Domains = 'domains',
   Events = 'events',
   Levels = 'levels',
@@ -44,6 +46,51 @@ type SchemaFields<T> = {
 }
 
 export const COLLECTIONS_MANIFEST: CollectionsManifest = new Map([
+  [
+    CollectionNames.ChainEvents,
+    {
+      create: {
+        validator: {
+          $jsonSchema: {
+            additionalProperties: false,
+            bsonType: 'object',
+            required: ['transaction', 'logIndex', 'address', 'topics', 'data'],
+            properties: {
+              _id: { bsonType: 'objectId' },
+              transaction: {
+                bsonType: 'string',
+                maxLength: 66,
+                minLength: 66,
+              },
+              logIndex: {
+                bsonType: 'number',
+                minimum: 0
+              },
+              address: {
+                bsonType: 'string',
+                maxLength: 42,
+                minLength: 42,
+              },
+              topics: {
+                bsonType: 'array',
+                items: {
+                  bsonType: 'string',
+                },
+              },
+              data: {
+                bsonType: 'string',
+              },
+            } as SchemaFields<ChainEventDoc>,
+          },
+        },
+      },
+      indexes: [
+        ['transaction', {}],
+        ['address', {}],
+        ['topics', {}],
+      ],
+    },
+  ],
   [
     CollectionNames.Users,
     {

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -89,7 +89,7 @@ export class ColonyMongoApi {
     logIndex: number,
     address: string,
     topics: string[],
-    data: boolean,
+    data: string,
   ) {
     const doc: Omit<ChainEventDoc, '_id'> = {
       transaction,

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -34,6 +34,7 @@ import {
   SuggestionDoc,
   TaskDoc,
   UserDoc,
+  ChainEventDoc,
 } from './types'
 import { CollectionNames } from './collections'
 import { matchUsernames } from './matchers'
@@ -61,6 +62,7 @@ export class ColonyMongoApi {
   private readonly suggestions: Collection<SuggestionDoc>
   private readonly tasks: Collection<TaskDoc>
   private readonly users: Collection<UserDoc>
+  private readonly chainEvents: Collection<ChainEventDoc>
 
   constructor(db: Db) {
     this.colonies = db.collection<ColonyDoc>(CollectionNames.Colonies)
@@ -78,6 +80,26 @@ export class ColonyMongoApi {
     this.suggestions = db.collection<SuggestionDoc>(CollectionNames.Suggestions)
     this.tasks = db.collection<TaskDoc>(CollectionNames.Tasks)
     this.users = db.collection<UserDoc>(CollectionNames.Users)
+    this.chainEvents = db.collection<ChainEventDoc>(CollectionNames.ChainEvents)
+  }
+
+
+  async recordChainEvent(
+    transaction: string,
+    logIndex: number,
+    address: string,
+    topics: string[],
+    data: boolean,
+  ) {
+    const doc: Omit<ChainEventDoc, '_id'> = {
+      transaction,
+      logIndex,
+      address,
+      topics,
+      data,
+    }
+
+    return this.chainEvents.updateOne(doc, { $setOnInsert: doc }, { upsert: true })
   }
 
   private async updateUser(

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -168,6 +168,14 @@ export interface TokenDoc extends MongoDoc {
   symbol: string
 }
 
+export interface ChainEventDoc extends MongoDoc {
+  transaction: string
+  logIndex: number
+  address: string
+  topics: string[]
+  data: string
+}
+
 export interface NotificationDoc extends MongoDoc {
   eventId: ObjectID
   users: { address: string; read?: boolean }[]

--- a/src/eventMonitor/index.ts
+++ b/src/eventMonitor/index.ts
@@ -3,177 +3,220 @@ import { IColonyNetworkFactory } from '../network/contracts/IColonyNetworkFactor
 import { IColonyFactory } from '../network/contracts/IColonyFactory'
 import { utils } from 'ethers'
 import { web3 } from 'Web3'
-import {
-  ChainEventDoc,
-} from './types'
+import { ChainEventDoc } from './types'
 
 class EventMonitor {
-    constructor (db: Db, provider: Provider) {
-        this.provider = provider
-        this.db = db
-        this.api = new ColonyMongoApi(db)
-        this.network = IColonyNetworkFactory.connect(
-            process.env.NETWORK_CONTRACT_ADDRESS,
-            provider,
-        )
-        this.colonyAddresses = []
-        // We hook off this dummy colony to get access to events
-        this.dummyColony = IColonyFactory.connect("0x0000000000000000000000000000000000000000", this.provider)
+  constructor(db: Db, provider: Provider) {
+    this.provider = provider
+    this.db = db
+    this.api = new ColonyMongoApi(db)
+    this.network = IColonyNetworkFactory.connect(
+      process.env.NETWORK_CONTRACT_ADDRESS,
+      provider,
+    )
+    this.colonyAddresses = []
+    // We hook off this dummy colony to get access to events
+    this.dummyColony = IColonyFactory.connect(
+      '0x0000000000000000000000000000000000000000',
+      this.provider,
+    )
 
-        // We're gonna need this later
-        this.topicMapping = {}
-        Object.keys(this.dummyColony.interface.events).forEach(eName => this.topicMapping[this.dummyColony.interface.events[eName].topic] = eName)
-        this.logsToProcess = []
-        this.blocksToProcess = []
-        // Every second, check the queue of events to affect the database
-        this.logQueueTimerId = setInterval(this.processLogQueue.bind(this), 1000)
-        // Every 15 seconds, check the queue of blocks we've not processed
-        this.blockQueueTimerId = setInterval(this.processBlockQueue.bind(this), 15000)
+    // We're gonna need this later
+    this.topicMapping = {}
+    Object.keys(this.dummyColony.interface.events).forEach(
+      (eName) =>
+        (this.topicMapping[
+          this.dummyColony.interface.events[eName].topic
+        ] = eName),
+    )
+    this.logsToProcess = []
+    this.blocksToProcess = []
+    // Every second, check the queue of events to affect the database
+    this.logQueueTimerId = setInterval(this.processLogQueue.bind(this), 1000)
+    // Every 15 seconds, check the queue of blocks we've not processed
+    this.blockQueueTimerId = setInterval(
+      this.processBlockQueue.bind(this),
+      15000,
+    )
+  }
+
+  private async processBlockQueue() {
+    if (this.blockProcessing === true) {
+      return
+    }
+    this.blockProcessing = true
+    // No async calls above here, otherwise it's race-condition city
+    while (this.blocksToProcess.length > 0) {
+      const blockNumberToProcess = this.blocksToProcess.shift()
+      await this.queueEvents(blockNumberToProcess)
     }
 
-    private async processBlockQueue() {
-        if (this.blockProcessing === true) {
-            return
-        }
-        this.blockProcessing = true
-        // No async calls above here, otherwise it's race-condition city
-        while (this.blocksToProcess.length > 0) {
-            const blockNumberToProcess = this.blocksToProcess.shift()
-            await this.queueEvents(blockNumberToProcess)
-        }
+    this.blockProcessing = false
+  }
 
-        this.blockProcessing = false
+  async queueEvents(blockNumber: Number) {
+    this.topicFilter.fromBlock = blockNumber
+    this.topicFilter.toBlock = blockNumber
+    let logs = []
+    try {
+      logs = await this.provider.getLogs(this.topicFilter)
+    } catch (e) {
+      console.log(
+        `getLogs failed with error ${e}. Some events might have been missed`,
+      )
+      return
+    }
+    if (logs.length > 500) {
+      console.log(
+        `Warning: Log length over 500 in a single block. Multiple filters might be required soon`,
+      )
+    }
+    logs.forEach(async (log) => {
+      if (this.colonyAddresses.indexOf(log.address) === -1) {
+        return
+      }
+      this.logsToProcess.push(log)
+    })
+  }
+
+  private async processLogQueue() {
+    if (this.logProcessing === true) {
+      return
+    }
+    this.logProcessing = true
+    // No async calls above here, otherwise it's race-condition city
+    while (this.logsToProcess.length > 0) {
+      // Get log
+      const {
+        transactionHash,
+        logIndex,
+        address,
+        topics,
+        data,
+      } = this.logsToProcess.shift()
+      const res = await this.api.recordChainEvent(
+        transactionHash,
+        logIndex,
+        address,
+        topics,
+        data,
+      )
+      // TODO: If the process gets killed here, the effect of this event will never be applied to the db. An edge case, but a case
+      // nonetheless
+      if (res?.result?.upserted) {
+        // This property only appears if we didn't have the log previously, so process the consequences
+        await this.processEventConsequences(log)
+      }
     }
 
-    async queueEvents(blockNumber: Number){
-        this.topicFilter.fromBlock = blockNumber
-        this.topicFilter.toBlock = blockNumber
-        let logs = []
-        try {
-            logs = await this.provider.getLogs(this.topicFilter)
-        } catch (e) {
-            console.log(`getLogs failed with error ${e}. Some events might have been missed`)
-            return
-        }
-        if (logs.length > 500) {
-            console.log(`Warning: Log length over 500 in a single block. Multiple filters might be required soon`)
-        }
-        logs.forEach(async (log) => {
-            if (this.colonyAddresses.indexOf(log.address) === -1) { return; }
-            this.logsToProcess.push(log)
-        })
+    this.logProcessing = false
+  }
+
+  async processEventConsequences(event: ChainEventDoc) {
+    const eventSig = this.topicMapping[event.topics[0]]
+    if (!eventSig) {
+      return
+    }
+    if (eventSig === 'DomainAdded(uint256)') {
+      const domain = await this.api.domains.findOne({
+        colonyAddress: event.address,
+        ethDomainId: parseInt(event.data),
+      })
+      if (domain !== null) {
+        // Domain already exists, so return
+        console.log('Domain already exists, skipping')
+        return
+      }
+      // If it doesn't already exist, we should make it. We need to get the tx, to find out the parent ID
+      const tx = await this.provider.getTransaction(event.transactionHash)
+      const [, , parentId] = utils.defaultAbiCoder.decode(
+        ['uint256', 'uint256', 'uint256'],
+        utils.hexDataSlice(tx.data, 4),
+      )
+      // Copied almost-verbatim from inside the API...
+      // An upsert is used even if it's not strictly necessary because
+      // it's not the job of a unique index to preserve data integrity.
+      return this.api.domains.updateOne(
+        {
+          colonyAddress: event.address,
+          ethDomainId: parseInt(event.data),
+          ethParentDomainId: parentId.toNumber(),
+        },
+        {
+          $setOnInsert: {
+            colonyAddress: event.address,
+            ethDomainId: parseInt(event.data),
+            ethParentDomainId: parentId.toNumber(),
+            name: `Domain #${parseInt(event.data)}`,
+          },
+        },
+        { upsert: true },
+      )
+    }
+  }
+
+  private async catchUpEvents() {
+    // Get the most recent event we added
+    const latestEvent = await this.api.chainEvents.findOne(
+      {},
+      { sort: [['_id', -1]] },
+    )
+    let blockNumber
+    if (latestEvent === null) {
+      blockNumber = await this.provider.getBlockNumber()
+    } else {
+      // Get the block it was in
+      const tx = await this.provider.getTransaction(latestEvent.transaction)
+      blockNumber = tx.blockNumber
+    }
+    // We start resyncing from 20 blocks back to accommodate reorgs
+    const fromBlock = blockNumber - 20
+    const latestBlock = await this.provider.getBlockNumber()
+    const nBlocks = latestBlock - fromBlock + 1
+    this.blocksToProcess = [...Array(nBlocks).keys()].map((x) => x + fromBlock)
+
+    // Add future blocks to the block queue:
+    this.provider.on('block', async (blockNumber) => {
+      this.blocksToProcess.push(blockNumber)
+    })
+  }
+
+  async init() {
+    // First, get a list of colonies
+    const colonyAddedFilter = this.network.filters.ColonyAdded()
+    colonyAddedFilter.fromBlock = 1
+    let colonyAddedEvents = []
+    try {
+      colonyAddedEvents = await this.provider.getLogs(colonyAddedFilter)
+    } catch (e) {
+      console.log(`getLogs failed with error ${e}. Initialisation unsuccessful`)
+      return
+    }
+    colonyAddedEvents.forEach((e) => {
+      this.colonyAddresses.push(
+        utils.getAddress(`0x${e.topics[2].substring(26)}`),
+      )
+    })
+    // Set up listener for future colonies being created to be added to the array.
+    this.network.on(colonyAddedFilter, (e) => {
+      this.colonyAddresses.push(
+        utils.getAddress(`0x${e.topics[2].substring(26)}`),
+      )
+    })
+
+    // Set up single listener for all events from everywhere.
+    const topicsOfInterest = [
+      this.dummyColony.filters.DomainAdded(),
+      this.dummyColony.filters.FundingPotAdded(),
+    ].map((f) => f.topics[0])
+    this.topicFilter = {
+      topics: [topicsOfInterest],
     }
 
-    private async processLogQueue() {
-        if (this.logProcessing === true) {
-            return
-        }
-        this.logProcessing = true
-        // No async calls above here, otherwise it's race-condition city
-        while (this.logsToProcess.length > 0) {
-            // Get log
-            const { transactionHash, logIndex, address, topics, data } = this.logsToProcess.shift()
-            const res = await this.api.recordChainEvent(transactionHash, logIndex, address, topics, data)
-            // TODO: If the process gets killed here, the effect of this event will never be applied to the db. An edge case, but a case
-            // nonetheless
-            if (res?.result?.upserted) {
-                // This property only appears if we didn't have the log previously, so process the consequences
-                await this.processEventConsequences(log)
-            }
-        }
-
-        this.logProcessing = false
-    }
-
-    async processEventConsequences(event: ChainEventDoc) {
-        const eventSig = this.topicMapping[event.topics[0]]
-        if (!eventSig) { return; }
-        if (eventSig === "DomainAdded(uint256)") {
-            const domain = await this.api.domains.findOne({ colonyAddress: event.address, ethDomainId: parseInt(event.data) })
-            if (domain !== null) {
-                // Domain already exists, so return
-                console.log('Domain already exists, skipping')
-                return
-            }
-            // If it doesn't already exist, we should make it. We need to get the tx, to find out the parent ID
-            const tx = await this.provider.getTransaction(event.transactionHash)
-            const [,,parentId] = utils.defaultAbiCoder.decode(
-                [ 'uint256', 'uint256', 'uint256' ],
-                utils.hexDataSlice(tx.data, 4)
-            )
-            // Copied almost-verbatim from inside the API...
-            // An upsert is used even if it's not strictly necessary because
-            // it's not the job of a unique index to preserve data integrity.
-            return this.api.domains.updateOne(
-              { colonyAddress: event.address, ethDomainId:parseInt(event.data), ethParentDomainId: parentId.toNumber() },
-              {
-                $setOnInsert: {
-                  colonyAddress: event.address,
-                  ethDomainId:parseInt(event.data),
-                  ethParentDomainId: parentId.toNumber(),
-                  name: `Domain #${parseInt(event.data)}`,
-                },
-              },
-              { upsert: true },
-            )
-        }
-    }
-
-    private async catchUpEvents() {
-        // Get the most recent event we added
-        const latestEvent = await this.api.chainEvents.findOne({}, {sort: [['_id', -1]]})
-        let blockNumber
-        if (latestEvent === null) {
-            blockNumber = await this.provider.getBlockNumber()
-        } else {
-            // Get the block it was in
-            const tx = await this.provider.getTransaction(latestEvent.transaction)
-            blockNumber = tx.blockNumber
-        }
-        // We start resyncing from 20 blocks back to accommodate reorgs
-        const fromBlock = blockNumber - 20
-        const latestBlock = await this.provider.getBlockNumber()
-        const nBlocks = latestBlock - fromBlock + 1
-        this.blocksToProcess = [...Array(nBlocks).keys()].map(x => x+fromBlock)
-
-        // Add future blocks to the block queue:
-        this.provider.on('block', async (blockNumber) => {
-            this.blocksToProcess.push(blockNumber)
-        })
-    }
-
-    async init() {
-        // First, get a list of colonies
-        const colonyAddedFilter = this.network.filters.ColonyAdded()
-        colonyAddedFilter.fromBlock = 1
-        let colonyAddedEvents = [];
-        try {
-            colonyAddedEvents = await this.provider.getLogs(colonyAddedFilter)
-        } catch (e) {
-            console.log(`getLogs failed with error ${e}. Initialisation unsuccessful`)
-            return
-        }
-        colonyAddedEvents.forEach(e => {
-            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`))
-        })
-        // Set up listener for future colonies being created to be added to the array.
-        this.network.on(colonyAddedFilter, (e) => {
-            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`))
-        })
-
-        // Set up single listener for all events from everywhere.
-        const topicsOfInterest = [
-            this.dummyColony.filters.DomainAdded(),
-            this.dummyColony.filters.FundingPotAdded(),
-        ].map(f => f.topics[0])
-        this.topicFilter = {
-            topics: [topicsOfInterest]
-        }
-
-        await this.catchUpEvents()
-    }
+    await this.catchUpEvents()
+  }
 }
 
 export const createEventMonitor = (db: Db, provider: Provider) => {
-    return new EventMonitor(db, provider)
+  return new EventMonitor(db, provider)
 }

--- a/src/eventMonitor/index.ts
+++ b/src/eventMonitor/index.ts
@@ -1,0 +1,167 @@
+import { ColonyMongoApi } from '../db/colonyMongoApi'
+import { IColonyNetworkFactory } from '../network/contracts/IColonyNetworkFactory'
+import { IColonyFactory } from '../network/contracts/IColonyFactory'
+import { utils } from 'ethers';
+import { web3 } from 'Web3'
+import {
+  ChainEventDoc,
+} from './types'
+
+class EventMonitor {
+    constructor (db: Db, provider: Provider) {
+        this.provider = provider;
+        this.db = db;
+        this.api = new ColonyMongoApi(db)
+        this.network = IColonyNetworkFactory.connect(
+            process.env.NETWORK_CONTRACT_ADDRESS,
+            provider,
+        )
+        this.colonyAddresses = [];
+        // We hook off this dummy colony to get access to events
+        this.dummyColony = IColonyFactory.connect("0x0000000000000000000000000000000000000000", this.provider);
+
+        // We're gonna need this later
+        this.topicMapping = {};
+        Object.keys(this.dummyColony.interface.events).forEach(eName => this.topicMapping[this.dummyColony.interface.events[eName].topic] = eName);
+        this.logsToProcess = [];
+        this.blocksToProcess = [];
+        // Every second, check the queue of events to affect the database
+        this.logQueueTimerId = setInterval(this.processLogQueue.bind(this), 1000)
+        // Every 15 seconds, check the queue of blocks we've not processed
+        this.blockQueueTimerId = setInterval(this.processBlockQueue.bind(this), 15000)
+    }
+
+    private async processBlockQueue() {
+        if (this.blockProcessing === true) {
+            return;
+        }
+        this.blockProcessing = true;
+        // No async calls above here, otherwise it's race-condition city
+        while (this.blocksToProcess.length > 0) {
+            const blockNumberToProcess = this.blocksToProcess.shift()
+            await this.queueEvents(blockNumberToProcess);
+        }
+
+        this.blockProcessing = false;
+    }
+
+    async queueEvents(blockNumber: Number){
+        this.topicFilter.fromBlock = blockNumber;
+        this.topicFilter.toBlock = blockNumber;
+        const logs = await this.provider.getLogs(this.topicFilter);
+        if (logs.length > 500) {
+            console.log(`Warning: Log length over 500 in a single block. Multiple filters might be required soon`);
+        }
+        logs.forEach(async (log) => {
+            if (this.colonyAddresses.indexOf(log.address) === -1) { return; }
+            this.logsToProcess.push(log);
+        })
+    }
+
+    private async processLogQueue() {
+        if (this.logProcessing === true) {
+            return;
+        }
+        this.logProcessing = true;
+        // No async calls above here, otherwise it's race-condition city
+        while (this.logsToProcess.length > 0) {
+            // Get log
+            const log = this.logsToProcess.shift();
+            const res = await this.api.recordChainEvent(log.transactionHash, log.logIndex, log.address, log.topics, log.data);
+            // TODO: If the process gets killed here, the effect of this event will never be applied to the db. An edge case, but a case
+            // nonetheless
+            if (res.result.upserted) {
+                // This property only appears if we didn't have the log previously, so process the consequences
+                await this.processEventConsequences(log);
+            }
+        }
+
+        this.logProcessing = false;
+    }
+
+    async processEventConsequences(event: ChainEventDoc) {
+        const eventSig = this.topicMapping[event.topics[0]];
+        if (!eventSig) { return; }
+        if (eventSig === "DomainAdded(uint256)") {
+            const domain = await this.api.domains.findOne({ colonyAddress: event.address, ethDomainId: parseInt(event.data) })
+            if (domain !== null) {
+                // Domain already exists, so return
+                console.log('Domain already exists, skipping');
+                return;
+            }
+            // If it doesn't already exist, we should make it. We need to get the tx, to find out the parent ID
+            const tx = await this.provider.getTransaction(event.transactionHash);
+            const [,,parentId] = utils.defaultAbiCoder.decode(
+                [ 'uint256', 'uint256', 'uint256' ],
+                utils.hexDataSlice(tx.data, 4)
+            )
+            // Copied almost-verbatim from inside the API...
+            // An upsert is used even if it's not strictly necessary because
+            // it's not the job of a unique index to preserve data integrity.
+            return this.api.domains.updateOne(
+              { colonyAddress: event.address, ethDomainId:parseInt(event.data), ethParentDomainId: parentId.toNumber() },
+              {
+                $setOnInsert: {
+                  colonyAddress: event.address,
+                  ethDomainId:parseInt(event.data),
+                  ethParentDomainId: parentId.toNumber(),
+                  name: `Domain #${parseInt(event.data)}`,
+                },
+              },
+              { upsert: true },
+            )
+        }
+    }
+
+    private async catchUpEvents() {
+        // Get the most recent event we added
+        const latestEvent = await this.api.chainEvents.findOne({}, {sort: [['_id', -1]]});
+        let blockNumber;
+        if (latestEvent === null) {
+            blockNumber = await this.provider.getBlockNumber()
+        } else {
+            // Get the block it was in
+            const tx = await this.provider.getTransaction(latestEvent.transaction);
+            blockNumber = tx.blockNumber;
+        }
+        // We start resyncing from 20 blocks back to accommodate reorgs
+        const fromBlock = blockNumber - 20
+        const latestBlock = await this.provider.getBlockNumber()
+        const nBlocks = latestBlock - fromBlock + 1;
+        this.blocksToProcess = [...Array(nBlocks).keys()].map(x => x+fromBlock);
+
+        // Add future blocks to the block queue:
+        this.provider.on('block', async (blockNumber) => {
+            this.blocksToProcess.push(blockNumber);
+        });
+    }
+
+    async init() {
+        // First, get a list of colonies
+        const colonyAddedFilter = this.network.filters.ColonyAdded()
+        colonyAddedFilter.fromBlock = 1
+        const colonyAddedEvents = await this.provider.getLogs(colonyAddedFilter)
+        colonyAddedEvents.forEach(e => {
+            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`));
+        });
+        // Set up listener for future colonies being created to be added to the array.
+        this.network.on(colonyAddedFilter, (e) => {
+            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`));
+        });
+
+        // Set up single listener for all events from everywhere.
+        const topicsOfInterest = [
+            this.dummyColony.filters.DomainAdded(),
+            this.dummyColony.filters.FundingPotAdded(),
+        ].map(f => f.topics[0])
+        this.topicFilter = {
+            topics: [topicsOfInterest]
+        }
+
+        await this.catchUpEvents();
+    }
+}
+
+export const createEventMonitor = (db: Db, provider: Provider) => {
+    return new EventMonitor(db, provider);
+}

--- a/src/eventMonitor/index.ts
+++ b/src/eventMonitor/index.ts
@@ -1,7 +1,7 @@
 import { ColonyMongoApi } from '../db/colonyMongoApi'
 import { IColonyNetworkFactory } from '../network/contracts/IColonyNetworkFactory'
 import { IColonyFactory } from '../network/contracts/IColonyFactory'
-import { utils } from 'ethers';
+import { utils } from 'ethers'
 import { web3 } from 'Web3'
 import {
   ChainEventDoc,
@@ -9,22 +9,22 @@ import {
 
 class EventMonitor {
     constructor (db: Db, provider: Provider) {
-        this.provider = provider;
-        this.db = db;
+        this.provider = provider
+        this.db = db
         this.api = new ColonyMongoApi(db)
         this.network = IColonyNetworkFactory.connect(
             process.env.NETWORK_CONTRACT_ADDRESS,
             provider,
         )
-        this.colonyAddresses = [];
+        this.colonyAddresses = []
         // We hook off this dummy colony to get access to events
-        this.dummyColony = IColonyFactory.connect("0x0000000000000000000000000000000000000000", this.provider);
+        this.dummyColony = IColonyFactory.connect("0x0000000000000000000000000000000000000000", this.provider)
 
         // We're gonna need this later
-        this.topicMapping = {};
-        Object.keys(this.dummyColony.interface.events).forEach(eName => this.topicMapping[this.dummyColony.interface.events[eName].topic] = eName);
-        this.logsToProcess = [];
-        this.blocksToProcess = [];
+        this.topicMapping = {}
+        Object.keys(this.dummyColony.interface.events).forEach(eName => this.topicMapping[this.dummyColony.interface.events[eName].topic] = eName)
+        this.logsToProcess = []
+        this.blocksToProcess = []
         // Every second, check the queue of events to affect the database
         this.logQueueTimerId = setInterval(this.processLogQueue.bind(this), 1000)
         // Every 15 seconds, check the queue of blocks we've not processed
@@ -33,64 +33,70 @@ class EventMonitor {
 
     private async processBlockQueue() {
         if (this.blockProcessing === true) {
-            return;
+            return
         }
-        this.blockProcessing = true;
+        this.blockProcessing = true
         // No async calls above here, otherwise it's race-condition city
         while (this.blocksToProcess.length > 0) {
             const blockNumberToProcess = this.blocksToProcess.shift()
-            await this.queueEvents(blockNumberToProcess);
+            await this.queueEvents(blockNumberToProcess)
         }
 
-        this.blockProcessing = false;
+        this.blockProcessing = false
     }
 
     async queueEvents(blockNumber: Number){
-        this.topicFilter.fromBlock = blockNumber;
-        this.topicFilter.toBlock = blockNumber;
-        const logs = await this.provider.getLogs(this.topicFilter);
+        this.topicFilter.fromBlock = blockNumber
+        this.topicFilter.toBlock = blockNumber
+        let logs = []
+        try {
+            logs = await this.provider.getLogs(this.topicFilter)
+        } catch (e) {
+            console.log(`getLogs failed with error ${e}. Some events might have been missed`)
+            return
+        }
         if (logs.length > 500) {
-            console.log(`Warning: Log length over 500 in a single block. Multiple filters might be required soon`);
+            console.log(`Warning: Log length over 500 in a single block. Multiple filters might be required soon`)
         }
         logs.forEach(async (log) => {
             if (this.colonyAddresses.indexOf(log.address) === -1) { return; }
-            this.logsToProcess.push(log);
+            this.logsToProcess.push(log)
         })
     }
 
     private async processLogQueue() {
         if (this.logProcessing === true) {
-            return;
+            return
         }
-        this.logProcessing = true;
+        this.logProcessing = true
         // No async calls above here, otherwise it's race-condition city
         while (this.logsToProcess.length > 0) {
             // Get log
-            const log = this.logsToProcess.shift();
-            const res = await this.api.recordChainEvent(log.transactionHash, log.logIndex, log.address, log.topics, log.data);
+            const { transactionHash, logIndex, address, topics, data } = this.logsToProcess.shift()
+            const res = await this.api.recordChainEvent(transactionHash, logIndex, address, topics, data)
             // TODO: If the process gets killed here, the effect of this event will never be applied to the db. An edge case, but a case
             // nonetheless
-            if (res.result.upserted) {
+            if (res?.result?.upserted) {
                 // This property only appears if we didn't have the log previously, so process the consequences
-                await this.processEventConsequences(log);
+                await this.processEventConsequences(log)
             }
         }
 
-        this.logProcessing = false;
+        this.logProcessing = false
     }
 
     async processEventConsequences(event: ChainEventDoc) {
-        const eventSig = this.topicMapping[event.topics[0]];
+        const eventSig = this.topicMapping[event.topics[0]]
         if (!eventSig) { return; }
         if (eventSig === "DomainAdded(uint256)") {
             const domain = await this.api.domains.findOne({ colonyAddress: event.address, ethDomainId: parseInt(event.data) })
             if (domain !== null) {
                 // Domain already exists, so return
-                console.log('Domain already exists, skipping');
-                return;
+                console.log('Domain already exists, skipping')
+                return
             }
             // If it doesn't already exist, we should make it. We need to get the tx, to find out the parent ID
-            const tx = await this.provider.getTransaction(event.transactionHash);
+            const tx = await this.provider.getTransaction(event.transactionHash)
             const [,,parentId] = utils.defaultAbiCoder.decode(
                 [ 'uint256', 'uint256', 'uint256' ],
                 utils.hexDataSlice(tx.data, 4)
@@ -115,39 +121,45 @@ class EventMonitor {
 
     private async catchUpEvents() {
         // Get the most recent event we added
-        const latestEvent = await this.api.chainEvents.findOne({}, {sort: [['_id', -1]]});
-        let blockNumber;
+        const latestEvent = await this.api.chainEvents.findOne({}, {sort: [['_id', -1]]})
+        let blockNumber
         if (latestEvent === null) {
             blockNumber = await this.provider.getBlockNumber()
         } else {
             // Get the block it was in
-            const tx = await this.provider.getTransaction(latestEvent.transaction);
-            blockNumber = tx.blockNumber;
+            const tx = await this.provider.getTransaction(latestEvent.transaction)
+            blockNumber = tx.blockNumber
         }
         // We start resyncing from 20 blocks back to accommodate reorgs
         const fromBlock = blockNumber - 20
         const latestBlock = await this.provider.getBlockNumber()
-        const nBlocks = latestBlock - fromBlock + 1;
-        this.blocksToProcess = [...Array(nBlocks).keys()].map(x => x+fromBlock);
+        const nBlocks = latestBlock - fromBlock + 1
+        this.blocksToProcess = [...Array(nBlocks).keys()].map(x => x+fromBlock)
 
         // Add future blocks to the block queue:
         this.provider.on('block', async (blockNumber) => {
-            this.blocksToProcess.push(blockNumber);
-        });
+            this.blocksToProcess.push(blockNumber)
+        })
     }
 
     async init() {
         // First, get a list of colonies
         const colonyAddedFilter = this.network.filters.ColonyAdded()
         colonyAddedFilter.fromBlock = 1
-        const colonyAddedEvents = await this.provider.getLogs(colonyAddedFilter)
+        let colonyAddedEvents = [];
+        try {
+            colonyAddedEvents = await this.provider.getLogs(colonyAddedFilter)
+        } catch (e) {
+            console.log(`getLogs failed with error ${e}. Initialisation unsuccessful`)
+            return
+        }
         colonyAddedEvents.forEach(e => {
-            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`));
-        });
+            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`))
+        })
         // Set up listener for future colonies being created to be added to the array.
         this.network.on(colonyAddedFilter, (e) => {
-            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`));
-        });
+            this.colonyAddresses.push(utils.getAddress(`0x${e.topics[2].substring(26)}`))
+        })
 
         // Set up single listener for all events from everywhere.
         const topicsOfInterest = [
@@ -158,10 +170,10 @@ class EventMonitor {
             topics: [topicsOfInterest]
         }
 
-        await this.catchUpEvents();
+        await this.catchUpEvents()
     }
 }
 
 export const createEventMonitor = (db: Db, provider: Provider) => {
-    return new EventMonitor(db, provider);
+    return new EventMonitor(db, provider)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,12 @@ import { getTokenForAddress } from './auth'
 import { connect } from './db/connect'
 import { provider } from './network/provider'
 import { isDevelopment } from './env'
+import { createEventMonitor } from './eventMonitor'
 
 const startServer = async () => {
   const { db } = await connect()
   const apolloServer = createApolloServer(db, provider)
+  const eventMonitor = createEventMonitor(db, provider)
 
   const app = express()
   const port = process.env.APOLLO_PORT
@@ -51,6 +53,7 @@ const startServer = async () => {
       )
     }
   })
+  await eventMonitor.init();
 }
 
 startServer()


### PR DESCRIPTION
I think I've completed a proof-of-concept for how this could work, seems appropriate to open it up to feedback at this point. To add new events that we want to notice, we add the topic [here](https://github.com/JoinColony/colonyServer/compare/feat/event-monitor?expand=1#diff-064f10e61c0994fa4a07d746c446f2f8R153) and then add an appropriate branch to [this if statement](https://github.com/JoinColony/colonyServer/compare/feat/event-monitor?expand=1#diff-064f10e61c0994fa4a07d746c446f2f8R85) to deal with the consequences, whatever we decide they might be (here, the domain is added to the database with a default name, but events could be fired as well, or anything else).

I have a queue for both blocks and events to be processed; it doesn't feel like both should be necessary, but it was the best I came up with to reduce exposure to race conditions during startup or when one block ended up having multiple events that affected the same thing.

I am using `provider.getLogs` directly to allow me to pass arrays in the filter (which is not currently supported by ethers, but is by the RPC spec). Arrays allow us to say "I am interested in logs where the first topic is any of these", rather than filtering for just one topic. This means that we only make one request to get all of the events we are interested in (per block, as I've coded here). In theory, we can do the same to directly limit the addresses we're listening to to just colonies; I'm not sure whether asking the endpoints from hundreds of addresses or asking for everything and then filtering locally is better; I'm doing the latter for now. Note that Infura limits responses to 1000 events, so if we crossed that at any point we're going to be missing events. I've put a warning in if we ever got to 500 but that seems preposterously high as it is.

When started, it starts from 20 blocks before the most recent event that was added. It doesn't currently backfill everything from scratch, but that would be reasonably straightforward to add (modulo the Infura 1000 event limit). The function to add `ChainEvents` is idempotent, and that should hold even if a chain reorg occurred - the `txid` and the `logIndex` should uniquely identify an event even through a reorg. The one edge case I've not dealt with here is if there's a reorg, and the transaction is replaced rather than remined, but I don't think it's worth worrying about for now.

I took Raul's advice and I've just hooked in to the database where appropriate (the existing `createDomain` in the database API requires the colony and creating user to exist). We could make another API if we decide what we want to do makes it necessary.