### PR TITLE
Transaction Message Queries, Mutations and APIs

### DIFF
--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -508,6 +508,7 @@ export const COLLECTIONS_MANIFEST: CollectionsManifest = new Map([
         ['initiatorAddress', {}],
         ['context.colonyAddress', { sparse: true }],
         ['context.taskId', { sparse: true }],
+        ['context.txHash', { sparse: true }],
       ],
     },
   ],

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -508,7 +508,7 @@ export const COLLECTIONS_MANIFEST: CollectionsManifest = new Map([
         ['initiatorAddress', {}],
         ['context.colonyAddress', { sparse: true }],
         ['context.taskId', { sparse: true }],
-        ['context.txHash', { sparse: true }],
+        ['context.transactionHash', { sparse: true }],
       ],
     },
   ],

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -796,7 +796,9 @@ export class ColonyMongoApi {
      * This way we ensure that the asignee always gets notified
      */
     await this.subscribeToTask(initiator, taskId)
-    const workerExists = !!(await this.users.findOne({ walletAddress: workerAddress }))
+    const workerExists = !!(await this.users.findOne({
+      walletAddress: workerAddress,
+    }))
     if (workerExists) {
       await this.subscribeToTask(workerAddress, taskId)
     }
@@ -1559,5 +1561,19 @@ export class ColonyMongoApi {
       { _id: new ObjectID(levelId) },
       { $set: update },
     )
+  }
+
+  async sendTransactionMessage(
+    initiator: string,
+    transactionHash: string,
+    colonyAddress: string,
+    message: string,
+  ) {
+    await this.tryGetUser(initiator)
+    return this.createEvent(initiator, EventType.TransactionMessage, {
+      transactionHash,
+      message,
+      colonyAddress,
+    })
   }
 }

--- a/src/db/colonyMongoDataSource.ts
+++ b/src/db/colonyMongoDataSource.ts
@@ -776,4 +776,12 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
 
     return ColonyMongoDataSource.transformToken(token)
   }
+
+  async getTransactionMessages(transactionHash: string, ttl?: number) {
+    const query = { 'context.transactionHash': transactionHash }
+    const events = ttl
+      ? await this.collections.events.findManyByQuery(query, { ttl })
+      : await this.collections.events.collection.find(query).toArray()
+    return events.map(ColonyMongoDataSource.transformEvent)
+  }
 }

--- a/src/graphql/__tests__/apolloServer.test.ts
+++ b/src/graphql/__tests__/apolloServer.test.ts
@@ -22,6 +22,7 @@ import Suggestion from '../typeDefs/Suggestion'
 import Task from '../typeDefs/Task'
 import TokenInfo from '../typeDefs/TokenInfo'
 import SystemInfo from '../typeDefs/SystemInfo'
+import Transaction from '../typeDefs/Transaction'
 import User from '../typeDefs/User'
 import scalars from '../typeDefs/scalars'
 import { resolvers } from '../resolvers'
@@ -62,6 +63,7 @@ const typeDefs = [
   Task,
   TokenInfo,
   SystemInfo,
+  Transaction,
   User,
   scalars,
 ]

--- a/src/graphql/eventContext.d.ts
+++ b/src/graphql/eventContext.d.ts
@@ -23,6 +23,7 @@ import {
   TaskMessageEvent,
   UnassignWorkerEvent,
   UnlockNextLevelEvent,
+  TransactionMessageEvent,
 } from './types'
 
 interface EventContextMap {
@@ -49,6 +50,7 @@ interface EventContextMap {
   [EventType.UnassignWorker]: UnassignWorkerEvent
   [EventType.UnlockNextLevel]: UnlockNextLevelEvent
   [EventType.NewUser]: NewUserEvent
+  [EventType.TransactionMessage]: TransactionMessageEvent
 }
 
 export type EventContextOfType<T extends EventType> = Omit<

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -34,7 +34,7 @@ const authenticate = (token: string) => {
   let user
 
   // In dev mode we enable a mode without a token for code generation
-  if (isDevelopment && token === 'codegen') {
+  if (isDevelopment) {
     user = null
   } else {
     /**

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -35,7 +35,7 @@ const authenticate = (token: string) => {
   let user
 
   // In dev mode we enable a mode without a token for code generation
-  if (isDevelopment) {
+  if (isDevelopment && token === 'codegen') {
     user = null
   } else {
     /**

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -28,6 +28,7 @@ import Task from './typeDefs/Task'
 import TokenInfo from './typeDefs/TokenInfo'
 import SystemInfo from './typeDefs/SystemInfo'
 import User from './typeDefs/User'
+import Transaction from './typeDefs/Transaction'
 import scalars from './typeDefs/scalars'
 
 const authenticate = (token: string) => {
@@ -79,6 +80,7 @@ export const createApolloServer = (db: Db, provider: Provider) => {
       SystemInfo,
       User,
       scalars,
+      Transaction,
     ],
     resolvers,
     formatError: (err) => {

--- a/src/graphql/resolvers/Mutation.ts
+++ b/src/graphql/resolvers/Mutation.ts
@@ -466,6 +466,19 @@ export const Mutation: MutationResolvers<ApolloContext> = {
     await api.sendTaskMessage(userAddress, id, message)
     return true
   },
+  async sendTransactionMessage(
+    parent,
+    { input: { transactionHash, message, colonyAddress } },
+    { userAddress, api, dataSources: { data } },
+  ) {
+    await api.sendTransactionMessage(
+      userAddress,
+      transactionHash,
+      colonyAddress,
+      message,
+    )
+    return true
+  },
   // Domains
   async createDomain(
     parent,

--- a/src/graphql/resolvers/Query.ts
+++ b/src/graphql/resolvers/Query.ts
@@ -79,4 +79,15 @@ export const Query: QueryResolvers<ApolloContext> = {
     const system = new SystemDataSource()
     return system.getSystemInfo()
   },
+  async transactionMessages(
+    parent,
+    { transactionHash }: { transactionHash: string },
+    { dataSources: { data } },
+  ) {
+    const messages = await data.getTransactionMessages(transactionHash)
+    return {
+      transactionHash,
+      messages,
+    }
+  },
 }

--- a/src/graphql/typeDefs/Event.ts
+++ b/src/graphql/typeDefs/Event.ts
@@ -172,6 +172,13 @@ export default gql`
     submissionId: String!
   }
 
+  type TransactionMessageEvent {
+    type: EventType!
+    transactionHash: String!
+    message: String!
+    colonyAddress: String
+  }
+
   union EventContext =
       AcceptLevelTaskSubmissionEvent
     | AssignWorkerEvent
@@ -196,6 +203,7 @@ export default gql`
     | TaskMessageEvent
     | UnassignWorkerEvent
     | UnlockNextLevelEvent
+    | TransactionMessageEvent
 
   type Event {
     id: String!

--- a/src/graphql/typeDefs/Event.ts
+++ b/src/graphql/typeDefs/Event.ts
@@ -176,7 +176,7 @@ export default gql`
     type: EventType!
     transactionHash: String!
     message: String!
-    colonyAddress: String
+    colonyAddress: String!
   }
 
   union EventContext =

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -263,6 +263,12 @@ export default gql`
     id: String!
   }
 
+  input SendTransactionMessageInput {
+    transactionHash: String!
+    message: String!
+    colonyAddress: String!
+  }
+
   type Mutation {
     # Colonies
     createColony(input: CreateColonyInput!): Colony
@@ -273,6 +279,7 @@ export default gql`
     editDomainName(input: EditDomainNameInput!): Domain
     # Messages
     sendTaskMessage(input: SendTaskMessageInput!): Boolean!
+    sendTransactionMessage(input: SendTransactionMessageInput!): Boolean!
     # Notifications
     markAllNotificationsAsRead: Boolean!
     markNotificationAsRead(input: MarkNotificationAsReadInput!): Boolean!

--- a/src/graphql/typeDefs/Query.ts
+++ b/src/graphql/typeDefs/Query.ts
@@ -10,6 +10,6 @@ export default gql`
     task(id: String!): Task!
     tokenInfo(address: String!): TokenInfo!
     systemInfo: SystemInfo!
-    transaction: Transaction!
+    transactionMessages(transactionHash: String!): TransactionMessages!
   }
 `

--- a/src/graphql/typeDefs/Query.ts
+++ b/src/graphql/typeDefs/Query.ts
@@ -10,5 +10,6 @@ export default gql`
     task(id: String!): Task!
     tokenInfo(address: String!): TokenInfo!
     systemInfo: SystemInfo!
+    transaction: Transaction!
   }
 `

--- a/src/graphql/typeDefs/Transaction.ts
+++ b/src/graphql/typeDefs/Transaction.ts
@@ -1,0 +1,11 @@
+import { gql } from 'apollo-server-express'
+
+export default gql`
+  type TransactionEvents implements Event {
+    context: TransactionMessageEvent!
+  }
+
+  type Transaction {
+    events: [Event!]!
+  }
+`

--- a/src/graphql/typeDefs/Transaction.ts
+++ b/src/graphql/typeDefs/Transaction.ts
@@ -1,11 +1,8 @@
 import { gql } from 'apollo-server-express'
 
 export default gql`
-  type TransactionEvents implements Event {
-    context: TransactionMessageEvent!
-  }
-
-  type Transaction {
-    events: [Event!]!
+  type TransactionMessages {
+    transactionHash: String!
+    messages: [Event!]!
   }
 `

--- a/src/graphql/typeDefs/scalars.ts
+++ b/src/graphql/typeDefs/scalars.ts
@@ -27,5 +27,6 @@ export default gql`
     TaskMessage
     UnassignWorker
     UnlockNextLevel
+    TransactionMessage
   }
 `

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -910,7 +910,7 @@ export type Query = {
   task: Task;
   tokenInfo: TokenInfo;
   systemInfo: SystemInfo;
-  transaction: Transaction;
+  transactionMessages: TransactionMessages;
 };
 
 
@@ -947,6 +947,11 @@ export type QueryTaskArgs = {
 
 export type QueryTokenInfoArgs = {
   address: Scalars['String'];
+};
+
+
+export type QueryTransactionMessagesArgs = {
+  transactionHash: Scalars['String'];
 };
 
 export enum SubmissionStatus {
@@ -1048,14 +1053,10 @@ export type TokenInfo = {
   verified: Scalars['Boolean'];
 };
 
-export type TransactionEvents = Event & {
-   __typename?: 'TransactionEvents';
-  context: TransactionMessageEvent;
-};
-
-export type Transaction = {
-   __typename?: 'Transaction';
-  events: Array<Event>;
+export type TransactionMessages = {
+   __typename?: 'TransactionMessages';
+  transactionHash: Scalars['String'];
+  messages: Array<Event>;
 };
 
 export type User = {
@@ -1295,8 +1296,7 @@ export type ResolversTypes = {
   TaskPayout: ResolverTypeWrapper<TaskPayout>,
   Task: ResolverTypeWrapper<Task>,
   TokenInfo: ResolverTypeWrapper<TokenInfo>,
-  TransactionEvents: ResolverTypeWrapper<TransactionEvents>,
-  Transaction: ResolverTypeWrapper<Transaction>,
+  TransactionMessages: ResolverTypeWrapper<TransactionMessages>,
   User: ResolverTypeWrapper<User>,
   UserProfile: ResolverTypeWrapper<UserProfile>,
   GraphQLDateTime: ResolverTypeWrapper<Scalars['GraphQLDateTime']>,
@@ -1406,8 +1406,7 @@ export type ResolversParentTypes = {
   TaskPayout: TaskPayout,
   Task: Task,
   TokenInfo: TokenInfo,
-  TransactionEvents: TransactionEvents,
-  Transaction: Transaction,
+  TransactionMessages: TransactionMessages,
   User: User,
   UserProfile: UserProfile,
   GraphQLDateTime: Scalars['GraphQLDateTime'],
@@ -1790,7 +1789,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   task?: Resolver<ResolversTypes['Task'], ParentType, ContextType, RequireFields<QueryTaskArgs, 'id'>>,
   tokenInfo?: Resolver<ResolversTypes['TokenInfo'], ParentType, ContextType, RequireFields<QueryTokenInfoArgs, 'address'>>,
   systemInfo?: Resolver<ResolversTypes['SystemInfo'], ParentType, ContextType>,
-  transaction?: Resolver<ResolversTypes['Transaction'], ParentType, ContextType>,
+  transactionMessages?: Resolver<ResolversTypes['TransactionMessages'], ParentType, ContextType, RequireFields<QueryTransactionMessagesArgs, 'transactionHash'>>,
 };
 
 export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
@@ -1878,13 +1877,9 @@ export type TokenInfoResolvers<ContextType = any, ParentType extends ResolversPa
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
-export type TransactionEventsResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransactionEvents'] = ResolversParentTypes['TransactionEvents']> = {
-  context?: Resolver<ResolversTypes['TransactionMessageEvent'], ParentType, ContextType>,
-  __isTypeOf?: isTypeOfResolverFn<ParentType>,
-};
-
-export type TransactionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Transaction'] = ResolversParentTypes['Transaction']> = {
-  events?: Resolver<Array<ResolversTypes['Event']>, ParentType, ContextType>,
+export type TransactionMessagesResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransactionMessages'] = ResolversParentTypes['TransactionMessages']> = {
+  transactionHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  messages?: Resolver<Array<ResolversTypes['Event']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -1961,8 +1956,7 @@ export type Resolvers<ContextType = any> = {
   TaskPayout?: TaskPayoutResolvers<ContextType>,
   Task?: TaskResolvers<ContextType>,
   TokenInfo?: TokenInfoResolvers<ContextType>,
-  TransactionEvents?: TransactionEventsResolvers<ContextType>,
-  Transaction?: TransactionResolvers<ContextType>,
+  TransactionMessages?: TransactionMessagesResolvers<ContextType>,
   User?: UserResolvers<ContextType>,
   UserProfile?: UserProfileResolvers<ContextType>,
   GraphQLDateTime?: GraphQLScalarType,

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -248,7 +248,7 @@ export type TransactionMessageEvent = {
   type: EventType;
   transactionHash: Scalars['String'];
   message: Scalars['String'];
-  colonyAddress?: Maybe<Scalars['String']>;
+  colonyAddress: Scalars['String'];
 };
 
 export type EventContext = AcceptLevelTaskSubmissionEvent | AssignWorkerEvent | CancelTaskEvent | CreateDomainEvent | CreateTaskEvent | CreateLevelTaskSubmissionEvent | CreateWorkRequestEvent | EnrollUserInProgramEvent | FinalizeTaskEvent | NewUserEvent | RemoveTaskPayoutEvent | SendWorkInviteEvent | SetTaskDescriptionEvent | SetTaskDomainEvent | SetTaskDueDateEvent | SetTaskPayoutEvent | SetTaskPendingEvent | SetTaskSkillEvent | RemoveTaskSkillEvent | SetTaskTitleEvent | TaskMessageEvent | UnassignWorkerEvent | UnlockNextLevelEvent | TransactionMessageEvent;
@@ -556,6 +556,12 @@ export type RemoveProgramInput = {
   id: Scalars['String'];
 };
 
+export type SendTransactionMessageInput = {
+  transactionHash: Scalars['String'];
+  message: Scalars['String'];
+  colonyAddress: Scalars['String'];
+};
+
 export type Mutation = {
    __typename?: 'Mutation';
   createColony?: Maybe<Colony>;
@@ -564,6 +570,7 @@ export type Mutation = {
   createDomain?: Maybe<Domain>;
   editDomainName?: Maybe<Domain>;
   sendTaskMessage: Scalars['Boolean'];
+  sendTransactionMessage: Scalars['Boolean'];
   markAllNotificationsAsRead: Scalars['Boolean'];
   markNotificationAsRead: Scalars['Boolean'];
   createSuggestion?: Maybe<Suggestion>;
@@ -638,6 +645,11 @@ export type MutationEditDomainNameArgs = {
 
 export type MutationSendTaskMessageArgs = {
   input: SendTaskMessageInput;
+};
+
+
+export type MutationSendTransactionMessageArgs = {
+  input: SendTransactionMessageInput;
 };
 
 
@@ -1281,6 +1293,7 @@ export type ResolversTypes = {
   ReorderProgramLevelsInput: ReorderProgramLevelsInput,
   PublishProgramInput: PublishProgramInput,
   RemoveProgramInput: RemoveProgramInput,
+  SendTransactionMessageInput: SendTransactionMessageInput,
   Mutation: ResolverTypeWrapper<{}>,
   PersistentTaskStatus: PersistentTaskStatus,
   PersistentTask: ResolverTypeWrapper<PersistentTask>,
@@ -1391,6 +1404,7 @@ export type ResolversParentTypes = {
   ReorderProgramLevelsInput: ReorderProgramLevelsInput,
   PublishProgramInput: PublishProgramInput,
   RemoveProgramInput: RemoveProgramInput,
+  SendTransactionMessageInput: SendTransactionMessageInput,
   Mutation: {},
   PersistentTaskStatus: PersistentTaskStatus,
   PersistentTask: PersistentTask,
@@ -1650,7 +1664,7 @@ export type TransactionMessageEventResolvers<ContextType = any, ParentType exten
   type?: Resolver<ResolversTypes['EventType'], ParentType, ContextType>,
   transactionHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-  colonyAddress?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  colonyAddress?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -1701,6 +1715,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createDomain?: Resolver<Maybe<ResolversTypes['Domain']>, ParentType, ContextType, RequireFields<MutationCreateDomainArgs, 'input'>>,
   editDomainName?: Resolver<Maybe<ResolversTypes['Domain']>, ParentType, ContextType, RequireFields<MutationEditDomainNameArgs, 'input'>>,
   sendTaskMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendTaskMessageArgs, 'input'>>,
+  sendTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendTransactionMessageArgs, 'input'>>,
   markAllNotificationsAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>,
   markNotificationAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMarkNotificationAsReadArgs, 'input'>>,
   createSuggestion?: Resolver<Maybe<ResolversTypes['Suggestion']>, ParentType, ContextType, RequireFields<MutationCreateSuggestionArgs, 'input'>>,

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -243,7 +243,15 @@ export type UnlockNextLevelEvent = {
   submissionId: Scalars['String'];
 };
 
-export type EventContext = AcceptLevelTaskSubmissionEvent | AssignWorkerEvent | CancelTaskEvent | CreateDomainEvent | CreateTaskEvent | CreateLevelTaskSubmissionEvent | CreateWorkRequestEvent | EnrollUserInProgramEvent | FinalizeTaskEvent | NewUserEvent | RemoveTaskPayoutEvent | SendWorkInviteEvent | SetTaskDescriptionEvent | SetTaskDomainEvent | SetTaskDueDateEvent | SetTaskPayoutEvent | SetTaskPendingEvent | SetTaskSkillEvent | RemoveTaskSkillEvent | SetTaskTitleEvent | TaskMessageEvent | UnassignWorkerEvent | UnlockNextLevelEvent;
+export type TransactionMessageEvent = {
+   __typename?: 'TransactionMessageEvent';
+  type: EventType;
+  transactionHash: Scalars['String'];
+  message: Scalars['String'];
+  colonyAddress?: Maybe<Scalars['String']>;
+};
+
+export type EventContext = AcceptLevelTaskSubmissionEvent | AssignWorkerEvent | CancelTaskEvent | CreateDomainEvent | CreateTaskEvent | CreateLevelTaskSubmissionEvent | CreateWorkRequestEvent | EnrollUserInProgramEvent | FinalizeTaskEvent | NewUserEvent | RemoveTaskPayoutEvent | SendWorkInviteEvent | SetTaskDescriptionEvent | SetTaskDomainEvent | SetTaskDueDateEvent | SetTaskPayoutEvent | SetTaskPendingEvent | SetTaskSkillEvent | RemoveTaskSkillEvent | SetTaskTitleEvent | TaskMessageEvent | UnassignWorkerEvent | UnlockNextLevelEvent | TransactionMessageEvent;
 
 export type Event = {
    __typename?: 'Event';
@@ -902,6 +910,7 @@ export type Query = {
   task: Task;
   tokenInfo: TokenInfo;
   systemInfo: SystemInfo;
+  transaction: Transaction;
 };
 
 
@@ -1039,6 +1048,16 @@ export type TokenInfo = {
   verified: Scalars['Boolean'];
 };
 
+export type TransactionEvents = Event & {
+   __typename?: 'TransactionEvents';
+  context: TransactionMessageEvent;
+};
+
+export type Transaction = {
+   __typename?: 'Transaction';
+  events: Array<Event>;
+};
+
 export type User = {
    __typename?: 'User';
   id: Scalars['String'];
@@ -1098,7 +1117,8 @@ export enum EventType {
   SetTaskTitle = 'SetTaskTitle',
   TaskMessage = 'TaskMessage',
   UnassignWorker = 'UnassignWorker',
-  UnlockNextLevel = 'UnlockNextLevel'
+  UnlockNextLevel = 'UnlockNextLevel',
+  TransactionMessage = 'TransactionMessage'
 }
 
 
@@ -1204,7 +1224,8 @@ export type ResolversTypes = {
   CreateLevelTaskSubmissionEvent: ResolverTypeWrapper<CreateLevelTaskSubmissionEvent>,
   EnrollUserInProgramEvent: ResolverTypeWrapper<EnrollUserInProgramEvent>,
   UnlockNextLevelEvent: ResolverTypeWrapper<UnlockNextLevelEvent>,
-  EventContext: ResolversTypes['AcceptLevelTaskSubmissionEvent'] | ResolversTypes['AssignWorkerEvent'] | ResolversTypes['CancelTaskEvent'] | ResolversTypes['CreateDomainEvent'] | ResolversTypes['CreateTaskEvent'] | ResolversTypes['CreateLevelTaskSubmissionEvent'] | ResolversTypes['CreateWorkRequestEvent'] | ResolversTypes['EnrollUserInProgramEvent'] | ResolversTypes['FinalizeTaskEvent'] | ResolversTypes['NewUserEvent'] | ResolversTypes['RemoveTaskPayoutEvent'] | ResolversTypes['SendWorkInviteEvent'] | ResolversTypes['SetTaskDescriptionEvent'] | ResolversTypes['SetTaskDomainEvent'] | ResolversTypes['SetTaskDueDateEvent'] | ResolversTypes['SetTaskPayoutEvent'] | ResolversTypes['SetTaskPendingEvent'] | ResolversTypes['SetTaskSkillEvent'] | ResolversTypes['RemoveTaskSkillEvent'] | ResolversTypes['SetTaskTitleEvent'] | ResolversTypes['TaskMessageEvent'] | ResolversTypes['UnassignWorkerEvent'] | ResolversTypes['UnlockNextLevelEvent'],
+  TransactionMessageEvent: ResolverTypeWrapper<TransactionMessageEvent>,
+  EventContext: ResolversTypes['AcceptLevelTaskSubmissionEvent'] | ResolversTypes['AssignWorkerEvent'] | ResolversTypes['CancelTaskEvent'] | ResolversTypes['CreateDomainEvent'] | ResolversTypes['CreateTaskEvent'] | ResolversTypes['CreateLevelTaskSubmissionEvent'] | ResolversTypes['CreateWorkRequestEvent'] | ResolversTypes['EnrollUserInProgramEvent'] | ResolversTypes['FinalizeTaskEvent'] | ResolversTypes['NewUserEvent'] | ResolversTypes['RemoveTaskPayoutEvent'] | ResolversTypes['SendWorkInviteEvent'] | ResolversTypes['SetTaskDescriptionEvent'] | ResolversTypes['SetTaskDomainEvent'] | ResolversTypes['SetTaskDueDateEvent'] | ResolversTypes['SetTaskPayoutEvent'] | ResolversTypes['SetTaskPendingEvent'] | ResolversTypes['SetTaskSkillEvent'] | ResolversTypes['RemoveTaskSkillEvent'] | ResolversTypes['SetTaskTitleEvent'] | ResolversTypes['TaskMessageEvent'] | ResolversTypes['UnassignWorkerEvent'] | ResolversTypes['UnlockNextLevelEvent'] | ResolversTypes['TransactionMessageEvent'],
   Event: ResolverTypeWrapper<Omit<Event, 'context'> & { context: ResolversTypes['EventContext'] }>,
   Notification: ResolverTypeWrapper<Notification>,
   LevelStatus: LevelStatus,
@@ -1274,6 +1295,8 @@ export type ResolversTypes = {
   TaskPayout: ResolverTypeWrapper<TaskPayout>,
   Task: ResolverTypeWrapper<Task>,
   TokenInfo: ResolverTypeWrapper<TokenInfo>,
+  TransactionEvents: ResolverTypeWrapper<TransactionEvents>,
+  Transaction: ResolverTypeWrapper<Transaction>,
   User: ResolverTypeWrapper<User>,
   UserProfile: ResolverTypeWrapper<UserProfile>,
   GraphQLDateTime: ResolverTypeWrapper<Scalars['GraphQLDateTime']>,
@@ -1312,7 +1335,8 @@ export type ResolversParentTypes = {
   CreateLevelTaskSubmissionEvent: CreateLevelTaskSubmissionEvent,
   EnrollUserInProgramEvent: EnrollUserInProgramEvent,
   UnlockNextLevelEvent: UnlockNextLevelEvent,
-  EventContext: ResolversParentTypes['AcceptLevelTaskSubmissionEvent'] | ResolversParentTypes['AssignWorkerEvent'] | ResolversParentTypes['CancelTaskEvent'] | ResolversParentTypes['CreateDomainEvent'] | ResolversParentTypes['CreateTaskEvent'] | ResolversParentTypes['CreateLevelTaskSubmissionEvent'] | ResolversParentTypes['CreateWorkRequestEvent'] | ResolversParentTypes['EnrollUserInProgramEvent'] | ResolversParentTypes['FinalizeTaskEvent'] | ResolversParentTypes['NewUserEvent'] | ResolversParentTypes['RemoveTaskPayoutEvent'] | ResolversParentTypes['SendWorkInviteEvent'] | ResolversParentTypes['SetTaskDescriptionEvent'] | ResolversParentTypes['SetTaskDomainEvent'] | ResolversParentTypes['SetTaskDueDateEvent'] | ResolversParentTypes['SetTaskPayoutEvent'] | ResolversParentTypes['SetTaskPendingEvent'] | ResolversParentTypes['SetTaskSkillEvent'] | ResolversParentTypes['RemoveTaskSkillEvent'] | ResolversParentTypes['SetTaskTitleEvent'] | ResolversParentTypes['TaskMessageEvent'] | ResolversParentTypes['UnassignWorkerEvent'] | ResolversParentTypes['UnlockNextLevelEvent'],
+  TransactionMessageEvent: TransactionMessageEvent,
+  EventContext: ResolversParentTypes['AcceptLevelTaskSubmissionEvent'] | ResolversParentTypes['AssignWorkerEvent'] | ResolversParentTypes['CancelTaskEvent'] | ResolversParentTypes['CreateDomainEvent'] | ResolversParentTypes['CreateTaskEvent'] | ResolversParentTypes['CreateLevelTaskSubmissionEvent'] | ResolversParentTypes['CreateWorkRequestEvent'] | ResolversParentTypes['EnrollUserInProgramEvent'] | ResolversParentTypes['FinalizeTaskEvent'] | ResolversParentTypes['NewUserEvent'] | ResolversParentTypes['RemoveTaskPayoutEvent'] | ResolversParentTypes['SendWorkInviteEvent'] | ResolversParentTypes['SetTaskDescriptionEvent'] | ResolversParentTypes['SetTaskDomainEvent'] | ResolversParentTypes['SetTaskDueDateEvent'] | ResolversParentTypes['SetTaskPayoutEvent'] | ResolversParentTypes['SetTaskPendingEvent'] | ResolversParentTypes['SetTaskSkillEvent'] | ResolversParentTypes['RemoveTaskSkillEvent'] | ResolversParentTypes['SetTaskTitleEvent'] | ResolversParentTypes['TaskMessageEvent'] | ResolversParentTypes['UnassignWorkerEvent'] | ResolversParentTypes['UnlockNextLevelEvent'] | ResolversParentTypes['TransactionMessageEvent'],
   Event: Omit<Event, 'context'> & { context: ResolversParentTypes['EventContext'] },
   Notification: Notification,
   LevelStatus: LevelStatus,
@@ -1382,6 +1406,8 @@ export type ResolversParentTypes = {
   TaskPayout: TaskPayout,
   Task: Task,
   TokenInfo: TokenInfo,
+  TransactionEvents: TransactionEvents,
+  Transaction: Transaction,
   User: User,
   UserProfile: UserProfile,
   GraphQLDateTime: Scalars['GraphQLDateTime'],
@@ -1621,8 +1647,16 @@ export type UnlockNextLevelEventResolvers<ContextType = any, ParentType extends 
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
+export type TransactionMessageEventResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransactionMessageEvent'] = ResolversParentTypes['TransactionMessageEvent']> = {
+  type?: Resolver<ResolversTypes['EventType'], ParentType, ContextType>,
+  transactionHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  colonyAddress?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
 export type EventContextResolvers<ContextType = any, ParentType extends ResolversParentTypes['EventContext'] = ResolversParentTypes['EventContext']> = {
-  __resolveType: TypeResolveFn<'AcceptLevelTaskSubmissionEvent' | 'AssignWorkerEvent' | 'CancelTaskEvent' | 'CreateDomainEvent' | 'CreateTaskEvent' | 'CreateLevelTaskSubmissionEvent' | 'CreateWorkRequestEvent' | 'EnrollUserInProgramEvent' | 'FinalizeTaskEvent' | 'NewUserEvent' | 'RemoveTaskPayoutEvent' | 'SendWorkInviteEvent' | 'SetTaskDescriptionEvent' | 'SetTaskDomainEvent' | 'SetTaskDueDateEvent' | 'SetTaskPayoutEvent' | 'SetTaskPendingEvent' | 'SetTaskSkillEvent' | 'RemoveTaskSkillEvent' | 'SetTaskTitleEvent' | 'TaskMessageEvent' | 'UnassignWorkerEvent' | 'UnlockNextLevelEvent', ParentType, ContextType>
+  __resolveType: TypeResolveFn<'AcceptLevelTaskSubmissionEvent' | 'AssignWorkerEvent' | 'CancelTaskEvent' | 'CreateDomainEvent' | 'CreateTaskEvent' | 'CreateLevelTaskSubmissionEvent' | 'CreateWorkRequestEvent' | 'EnrollUserInProgramEvent' | 'FinalizeTaskEvent' | 'NewUserEvent' | 'RemoveTaskPayoutEvent' | 'SendWorkInviteEvent' | 'SetTaskDescriptionEvent' | 'SetTaskDomainEvent' | 'SetTaskDueDateEvent' | 'SetTaskPayoutEvent' | 'SetTaskPendingEvent' | 'SetTaskSkillEvent' | 'RemoveTaskSkillEvent' | 'SetTaskTitleEvent' | 'TaskMessageEvent' | 'UnassignWorkerEvent' | 'UnlockNextLevelEvent' | 'TransactionMessageEvent', ParentType, ContextType>
 };
 
 export type EventResolvers<ContextType = any, ParentType extends ResolversParentTypes['Event'] = ResolversParentTypes['Event']> = {
@@ -1756,6 +1790,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   task?: Resolver<ResolversTypes['Task'], ParentType, ContextType, RequireFields<QueryTaskArgs, 'id'>>,
   tokenInfo?: Resolver<ResolversTypes['TokenInfo'], ParentType, ContextType, RequireFields<QueryTokenInfoArgs, 'address'>>,
   systemInfo?: Resolver<ResolversTypes['SystemInfo'], ParentType, ContextType>,
+  transaction?: Resolver<ResolversTypes['Transaction'], ParentType, ContextType>,
 };
 
 export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
@@ -1843,6 +1878,16 @@ export type TokenInfoResolvers<ContextType = any, ParentType extends ResolversPa
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
+export type TransactionEventsResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransactionEvents'] = ResolversParentTypes['TransactionEvents']> = {
+  context?: Resolver<ResolversTypes['TransactionMessageEvent'], ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type TransactionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Transaction'] = ResolversParentTypes['Transaction']> = {
+  events?: Resolver<Array<ResolversTypes['Event']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
 export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   createdAt?: Resolver<ResolversTypes['GraphQLDateTime'], ParentType, ContextType>,
@@ -1900,6 +1945,7 @@ export type Resolvers<ContextType = any> = {
   CreateLevelTaskSubmissionEvent?: CreateLevelTaskSubmissionEventResolvers<ContextType>,
   EnrollUserInProgramEvent?: EnrollUserInProgramEventResolvers<ContextType>,
   UnlockNextLevelEvent?: UnlockNextLevelEventResolvers<ContextType>,
+  TransactionMessageEvent?: TransactionMessageEventResolvers<ContextType>,
   EventContext?: EventContextResolvers,
   Event?: EventResolvers<ContextType>,
   Notification?: NotificationResolvers<ContextType>,
@@ -1915,6 +1961,8 @@ export type Resolvers<ContextType = any> = {
   TaskPayout?: TaskPayoutResolvers<ContextType>,
   Task?: TaskResolvers<ContextType>,
   TokenInfo?: TokenInfoResolvers<ContextType>,
+  TransactionEvents?: TransactionEventsResolvers<ContextType>,
+  Transaction?: TransactionResolvers<ContextType>,
   User?: UserResolvers<ContextType>,
   UserProfile?: UserProfileResolvers<ContextType>,
   GraphQLDateTime?: GraphQLScalarType,


### PR DESCRIPTION
This is a simple PR that adds to the current `Events` system a new context type, `TransactionMessageEvent` which will be used to add comments on the various transactions in the dApp.

**Changes**
- [x] Added `sendTransactionMessage` mongo api
- [x] Added `getTransactionMessages` mongo data source
- [x] Added `sendTransactionMessage` mutation resolver
- [x] Added `transactionMessages` query resolver
- [x] Added in, an generated the various types needed for this

**Query**
```graphql
fragment EventFields on Event {
  createdAt
  initiator {
    id
    profile {
      avatarHash
      displayName
      username
      walletAddress
    }
  }
  initiatorAddress
  sourceId
  sourceType
  type
}

fragment EventContext on Event {
    context {
    ... on TransactionMessageEvent {
      type
      transactionHash
      message
      colonyAddress
    }
  }
}

fragment TransactionMessage on Event {
  ...EventFields
  ...EventContext
}

query TransactionMessages($transactionHash: String!) {
  transactionMessages(transactionHash: $transactionHash) {
    transactionHash
    messages {
    	...TransactionMessage
    }
  }
}
```
Having the following query variables:
```json
{
  "transactionHash": "0x123"
}
```

**Mutation**
```graphql
mutation SendTransactionMessage($input: SendTransactionMessageInput!) {
  sendTransactionMessage(input: $input)
}
```

Having the following mutation input:
```json
{
  "input": {
    "transactionHash": "0x123",
    "message": "Hello World!",
    "colonyAddress": "0x123"
  }
}
```