### PR TITLE
GraphQL Subscriptions Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1442,6 +1442,56 @@
         }
       }
     },
+    "@graphql-tools/merge": {
+      "version": "6.2.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.16.tgz",
+      "integrity": "sha512-KjZ1pppzKcr2Uspgb53p8uw5yhWVuGIL+sEroar7vLsClSsuiGib8OKVICAGWjC9wrCxGaL9SjJGavfXpJMQIg==",
+      "requires": {
+        "@graphql-tools/schema": "^8.0.1",
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.0.1.tgz",
+      "integrity": "sha512-QG2HGLJjmsNc1wcj+rwZTEArgfMp7rsrb8iVq4P8ce1mDYAt6kRV6bLyPVb9q/j8Ik2zBc/B/Y1jPsnAVUHwdA==",
+      "requires": {
+        "@graphql-tools/merge": "6.2.16",
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.1.tgz",
+      "integrity": "sha512-gjQk6sht4b0/hcG+QEVxfMyO8bn5tuU1nIOVhQ4whgFaUmrnb3hx2mwzz1EJzfIOAuHKE8tY0lu6jt3bGTD4yg==",
+      "requires": {
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -13654,25 +13704,15 @@
       "dev": true
     },
     "subscriptions-transport-ws": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
-      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
+      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
       "requires": {
         "backo2": "^1.0.2",
         "eventemitter3": "^3.1.0",
         "iterall": "^1.2.1",
         "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "supports-color": {
@@ -14436,6 +14476,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-or-promise": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.10.tgz",
+      "integrity": "sha512-1OwTzvcfXkAfabk60UVr5NdjtjJ0Fg0T5+B1bhxtrOEwSH2fe8y4DnLgoksfCyd8yZCOQQHB0qLMQnwgCjbXLQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5564,6 +5564,13 @@
         "setimmediate": "1.0.4",
         "uuid": "2.0.1",
         "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
       }
     },
     "ethjs-unit": {
@@ -14438,9 +14445,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@graphql-tools/schema": "^8.0.1",
     "apollo-datasource-mongo": "git://github.com/jameslefrere/apollo-datasource-mongodb.git#12f6b7977d7a6a874f8c5473e4a70239ce7ee5b1",
     "apollo-datasource-rest": "0.8.1",
     "apollo-server-express": "2.12.0",
@@ -47,6 +48,7 @@
     "jose": "1.26.1",
     "linkify-it": "2.2.0",
     "mongodb": "3.5.6",
+    "subscriptions-transport-ws": "^0.9.19",
     "web3-utils": "1.2.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "linkify-it": "2.2.0",
     "mongodb": "3.5.6",
     "subscriptions-transport-ws": "^0.9.19",
+    "uuid": "^8.3.2",
     "web3-utils": "1.2.7"
   },
   "devDependencies": {

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -174,23 +174,33 @@ export class ColonyMongoApi {
   async subscribeToColony(initiator: string, colonyAddress: string) {
     await this.tryGetUser(initiator)
 
-    return this.updateUser(
+    const subscribedUser = await this.updateUser(
       initiator,
       // @ts-ignore This is too fiddly to type, for now
       { colonyAddresses: { $ne: colonyAddress } },
       { $addToSet: { colonyAddresses: colonyAddress } },
     )
+    this.pubsub.publish(SubscriptionLabel.ColonySubscriptionUpdated, {
+      colonyAddress,
+    })
+
+    return subscribedUser
   }
 
   async unsubscribeFromColony(initiator: string, colonyAddress: string) {
     await this.tryGetUser(initiator)
 
-    return this.updateUser(
+    const unsubscribedUser = await this.updateUser(
       initiator,
       // @ts-ignore This is too fiddly to type, for now
       { colonyAddresses: colonyAddress },
       { $pull: { colonyAddresses: colonyAddress } },
     )
+    this.pubsub.publish(SubscriptionLabel.ColonySubscriptionUpdated, {
+      colonyAddress,
+    })
+
+    return unsubscribedUser
   }
 
   async setUserTokens(initiator: string, tokenAddresses: string[]) {

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -12,6 +12,7 @@ import { PubSub } from 'graphql-subscriptions'
 import { ROOT_DOMAIN, AUTO_SUBSCRIBED_COLONIES } from '../constants'
 import { isETH } from '../utils'
 import { EventContextOfType } from '../graphql/eventContext'
+import { SubscriptionLabel } from '../graphql/subscriptionTypes'
 import { EventType, SuggestionStatus } from '../graphql/types'
 import {
   ColonyDoc,
@@ -26,8 +27,6 @@ import {
   LevelDoc,
 } from './types'
 import { CollectionNames } from './collections'
-import { matchUsernames } from './matchers'
-import { ColonyMongoDataSource } from './colonyMongoDataSource'
 
 export class ColonyMongoApi {
   private static createEditUpdater(edit: Record<string, any>) {
@@ -316,7 +315,9 @@ export class ColonyMongoApi {
         colonyAddress,
       },
     )
-    this.pubsub.publish('TRANSACTION_MESSAGE_ADDED', { transactionHash })
+    this.pubsub.publish(SubscriptionLabel.TransactionMessageAdded, {
+      transactionHash,
+    })
     return newTransactionMessageId
   }
 }

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -317,6 +317,7 @@ export class ColonyMongoApi {
     )
     this.pubsub.publish(SubscriptionLabel.TransactionMessageAdded, {
       transactionHash,
+      colonyAddress,
     })
     return newTransactionMessageId
   }

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -27,6 +27,7 @@ import {
 } from './types'
 import { CollectionNames } from './collections'
 import { matchUsernames } from './matchers'
+import { ColonyMongoDataSource } from './colonyMongoDataSource'
 
 export class ColonyMongoApi {
   private static createEditUpdater(edit: Record<string, any>) {
@@ -315,15 +316,7 @@ export class ColonyMongoApi {
         colonyAddress,
       },
     )
-    const messages = await this.events
-      .find({ 'context.transactionHash': transactionHash })
-      .toArray()
-    this.pubsub.publish('TRANSACTION_MESSAGE_ADDED', {
-      transactionMessages: {
-        transactionHash,
-        messages,
-      },
-    })
+    this.pubsub.publish('TRANSACTION_MESSAGE_ADDED', { transactionHash })
     return newTransactionMessageId
   }
 }

--- a/src/db/colonyMongoDataSource.ts
+++ b/src/db/colonyMongoDataSource.ts
@@ -83,13 +83,14 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
     }
   }
 
-  private static transformEvent<C extends object>({
+  static transformEvent<C extends object>({
     _id,
     context,
     type,
     ...doc
   }: EventDoc<C>): Event {
     const id = _id.toHexString()
+    console.log(doc)
     return {
       ...doc,
       id,
@@ -243,11 +244,11 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
     const [token] = ttl
       ? await this.collections.tokens.findManyByQuery(query, { ttl })
       : [await this.collections.tokens.collection.findOne(query)]
-  
+
     if (!token) {
       throw new Error(`Token with address '${tokenAddress}' not found`)
     }
-  
+
     return ColonyMongoDataSource.transformToken(token)
   }
 

--- a/src/db/colonyMongoDataSource.ts
+++ b/src/db/colonyMongoDataSource.ts
@@ -90,7 +90,6 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
     ...doc
   }: EventDoc<C>): Event {
     const id = _id.toHexString()
-    console.log(doc)
     return {
       ...doc,
       id,

--- a/src/graphql/__tests__/apolloServer.test.ts
+++ b/src/graphql/__tests__/apolloServer.test.ts
@@ -3,6 +3,7 @@ import { createTestClient } from 'apollo-server-testing'
 import { MongoClient, ObjectID } from 'mongodb'
 import fs from 'fs'
 import path from 'path'
+import { PubSub } from 'graphql-subscriptions'
 
 import { ColonyMongoApi } from '../../db/colonyMongoApi'
 import { ColonyMongoDataSource } from '../../db/colonyMongoDataSource'
@@ -100,6 +101,7 @@ describe('Apollo Server', () => {
   let api
   let data
   let auth
+  let pubsub
 
   const removeAll = async () => {
     await db.collection(CollectionNames.Colonies).deleteMany({})
@@ -116,8 +118,9 @@ describe('Apollo Server', () => {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     })
+    pubsub = new PubSub()
     db = await connection.db()
-    api = new ColonyMongoApi(db)
+    api = new ColonyMongoApi(db, pubsub)
     data = new ColonyMongoDataSource(db)
     auth = new ColonyAuthDataSource({} as any)
     await removeAll()

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -122,6 +122,27 @@ export const createSubscriptionServer = (server, path) => {
       schema,
       execute,
       subscribe,
+      /*
+       * Subscriptions JWT Authentication
+       *
+       * In theory this works just as with the query/mutation authentication,
+       * however, unlike the request based model of queries/mutations, once
+       * the websocket connection is open it will stay open (an re-connect),
+       * meaning the wallet address with which you first subscribed will
+       * stay the same for the whole session.
+       *
+       * This gets a bit complicated with ethereal wallets (which are temporary),
+       * but on the other hand this is just read-only public data, this whole
+       * authentication setup was done for consistency purpouses only.
+       *
+       * But beware, if you actually need to guard something against unauthorized
+       * reads, you will need to make sure, you use the correct wallet address
+       * when first subscribing and opening the websocket connection
+       */
+      onConnect: ({ authorization }: { authorization?: string } = {}) => {
+        const userAddress = authenticate(authorization)
+        return { userAddress }
+      },
       onOperation: (message, params) => ({
         ...params,
         context: { dataSources: { ...dataSources } },

--- a/src/graphql/resolvers/Query.ts
+++ b/src/graphql/resolvers/Query.ts
@@ -6,6 +6,14 @@ import { NetworkTokenInfo } from '../../external/tokenInfoDataSource'
 import { SystemDataSource } from '../../external/systemDataSource'
 import { getTokenDecimalsWithFallback } from '../../utils'
 
+export const getTransactionMessages = async (transactionHash, data) => {
+  const messages = await data.getTransactionMessages(transactionHash)
+  return {
+    transactionHash,
+    messages,
+  }
+}
+
 export const Query: QueryResolvers<ApolloContext> = {
   async user(parent, { address }, { dataSources: { data } }) {
     return data.getUserByAddress(address)
@@ -64,11 +72,7 @@ export const Query: QueryResolvers<ApolloContext> = {
     { transactionHash }: { transactionHash: string },
     { dataSources: { data } },
   ) {
-    const messages = await data.getTransactionMessages(transactionHash)
-    return {
-      transactionHash,
-      messages,
-    }
+    return await getTransactionMessages(transactionHash, data)
   },
   async transactionMessagesCount(
     parent,

--- a/src/graphql/resolvers/Query.ts
+++ b/src/graphql/resolvers/Query.ts
@@ -14,6 +14,13 @@ export const getTransactionMessages = async (transactionHash, data) => {
   }
 }
 
+export const getTransactionMessagesCount = async (colonyAddress, data) => {
+  const messagesCount = await data.getTransactionMessagesCount(colonyAddress)
+  return {
+    colonyTransactionMessages: messagesCount,
+  }
+}
+
 export const Query: QueryResolvers<ApolloContext> = {
   async user(parent, { address }, { dataSources: { data } }) {
     return data.getUserByAddress(address)
@@ -79,9 +86,6 @@ export const Query: QueryResolvers<ApolloContext> = {
     { colonyAddress }: { colonyAddress: string },
     { dataSources: { data } },
   ) {
-    const messagesCount = await data.getTransactionMessagesCount(colonyAddress)
-    return {
-      colonyTransactionMessages: messagesCount,
-    }
+    return await getTransactionMessagesCount(colonyAddress, data)
   },
 }

--- a/src/graphql/resolvers/Query.ts
+++ b/src/graphql/resolvers/Query.ts
@@ -21,6 +21,10 @@ export const getTransactionMessagesCount = async (colonyAddress, data) => {
   }
 }
 
+export const getSubscribedUsers = async (colonyAddress, data) => {
+  return await data.getColonySubscribedUsers(colonyAddress)
+}
+
 export const Query: QueryResolvers<ApolloContext> = {
   async user(parent, { address }, { dataSources: { data } }) {
     return data.getUserByAddress(address)
@@ -30,7 +34,7 @@ export const Query: QueryResolvers<ApolloContext> = {
     { colonyAddress }: { colonyAddress: string },
     { dataSources: { data } },
   ) {
-    return data.getColonySubscribedUsers(colonyAddress)
+    return await getSubscribedUsers(colonyAddress, data)
   },
   async tokenInfo(
     parent,

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -1,13 +1,15 @@
-import { ColonyMongoDataSource } from '../../db/colonyMongoDataSource'
 import { getTransactionMessages } from './Query'
+import { SubscriptionLabel } from '../subscriptionTypes'
 
 export const subscription = (pubsub) => ({
   transactionMessages: {
     resolve: async ({ transactionHash }, args, { dataSources: { data } }) =>
       await getTransactionMessages(transactionHash, data),
-    subscribe: () => pubsub.asyncIterator('TRANSACTION_MESSAGE_ADDED'),
+    subscribe: () =>
+      pubsub.asyncIterator(SubscriptionLabel.TransactionMessageAdded),
   },
   transactionMessagesCount: {
-    subscribe: () => pubsub.asyncIterator(['TRANSACTION_MESSAGE_ADDED']),
+    subscribe: () =>
+      pubsub.asyncIterator(SubscriptionLabel.TransactionMessageAdded),
   },
 })

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -1,4 +1,4 @@
-import { getTransactionMessages } from './Query'
+import { getTransactionMessages, getTransactionMessagesCount } from './Query'
 import { SubscriptionLabel } from '../subscriptionTypes'
 
 export const subscription = (pubsub) => ({
@@ -9,6 +9,8 @@ export const subscription = (pubsub) => ({
       pubsub.asyncIterator(SubscriptionLabel.TransactionMessageAdded),
   },
   transactionMessagesCount: {
+    resolve: async ({ colonyAddress }, args, { dataSources: { data } }) =>
+      await getTransactionMessagesCount(colonyAddress, data),
     subscribe: () =>
       pubsub.asyncIterator(SubscriptionLabel.TransactionMessageAdded),
   },

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -1,0 +1,14 @@
+import { ColonyMongoDataSource } from '../../db/colonyMongoDataSource'
+
+export const subscription = (pubsub) => ({
+  transactionMessages: {
+    resolve: ({ transactionMessages, transactionMessages: { messages } }) => ({
+      ...transactionMessages,
+      messages: messages.map(ColonyMongoDataSource.transformEvent),
+    }),
+    subscribe: () => pubsub.asyncIterator('TRANSACTION_MESSAGE_ADDED'),
+  },
+  transactionMessagesCount: {
+    subscribe: () => pubsub.asyncIterator(['TRANSACTION_MESSAGE_ADDED']),
+  },
+})

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -1,11 +1,10 @@
 import { ColonyMongoDataSource } from '../../db/colonyMongoDataSource'
+import { getTransactionMessages } from './Query'
 
 export const subscription = (pubsub) => ({
   transactionMessages: {
-    resolve: ({ transactionMessages, transactionMessages: { messages } }) => ({
-      ...transactionMessages,
-      messages: messages.map(ColonyMongoDataSource.transformEvent),
-    }),
+    resolve: async ({ transactionHash }, args, { dataSources: { data } }) =>
+      await getTransactionMessages(transactionHash, data),
     subscribe: () => pubsub.asyncIterator('TRANSACTION_MESSAGE_ADDED'),
   },
   transactionMessagesCount: {

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -1,17 +1,57 @@
+import { v4 as uuidv4 } from 'uuid'
+
 import { getTransactionMessages, getTransactionMessagesCount } from './Query'
 import { SubscriptionLabel } from '../subscriptionTypes'
 
+/*
+ * @NOTE Subscription Database Initialization Race Condition
+ *
+ * There's a race condition on the initial server startup, where, if the first
+ * thing the server receives is a subscription request (not a query or mutation)
+ * the database will not be yet initialized, and the first subscription response
+ * will be a mongo collections error.
+ *
+ * After a query/mutation has been fired, the database gets initialized properly
+ * and all subsequent subscriptions work as expected. Note that this is relevant
+ * only to the first server boot up, not to every subscription request.
+ *
+ * In the case of the dapp this is irrelevant as all subscription requests will
+ * only be made well after a bunch of queries and mutation have been fired,
+ * meaning the database has been properly initialized.
+ */
 export const subscription = (pubsub) => ({
   transactionMessages: {
     resolve: async ({ transactionHash }, args, { dataSources: { data } }) =>
       await getTransactionMessages(transactionHash, data),
-    subscribe: () =>
-      pubsub.asyncIterator(SubscriptionLabel.TransactionMessageAdded),
+    subscribe: (args, { transactionHash }) => {
+      /*
+       * @NOTE We need a client id to publish the subscription to, otherwise
+       * each new client subscription will reset and re-send all the subscription
+       * data out again
+       */
+      const id = uuidv4()
+      process.nextTick(() => pubsub.publish(id, { transactionHash }))
+      return pubsub.asyncIterator([
+        id,
+        SubscriptionLabel.TransactionMessageAdded,
+      ])
+    },
   },
   transactionMessagesCount: {
     resolve: async ({ colonyAddress }, args, { dataSources: { data } }) =>
       await getTransactionMessagesCount(colonyAddress, data),
-    subscribe: () =>
-      pubsub.asyncIterator(SubscriptionLabel.TransactionMessageAdded),
+    subscribe: (args, { colonyAddress }) => {
+      /*
+       * @NOTE We need a client id to publish the subscription to, otherwise
+       * each new client subscription will reset and re-send all the subscription
+       * data out again
+       */
+      const id = uuidv4()
+      process.nextTick(() => pubsub.publish(id, { colonyAddress }))
+      return pubsub.asyncIterator([
+        id,
+        SubscriptionLabel.TransactionMessageAdded,
+      ])
+    },
   },
 })

--- a/src/graphql/subscriptionTypes.ts
+++ b/src/graphql/subscriptionTypes.ts
@@ -1,0 +1,3 @@
+export enum SubscriptionLabel {
+  TransactionMessageAdded = 'TRANSACTION_MESSAGE_ADDED',
+}

--- a/src/graphql/subscriptionTypes.ts
+++ b/src/graphql/subscriptionTypes.ts
@@ -1,3 +1,4 @@
 export enum SubscriptionLabel {
   TransactionMessageAdded = 'TRANSACTION_MESSAGE_ADDED',
+  ColonySubscriptionUpdated = 'COLONY_SUBSCRIPTION_UPDATED',
 }

--- a/src/graphql/typeDefs/Subscriptions.ts
+++ b/src/graphql/typeDefs/Subscriptions.ts
@@ -1,0 +1,8 @@
+import { gql } from 'apollo-server-express'
+
+export default gql`
+  type Subscription {
+    transactionMessages(transactionHash: String!): TransactionMessages!
+    transactionMessagesCount(colonyAddress: String!): TransactionMessagesCount!
+  }
+`

--- a/src/graphql/typeDefs/Subscriptions.ts
+++ b/src/graphql/typeDefs/Subscriptions.ts
@@ -4,5 +4,6 @@ export default gql`
   type Subscription {
     transactionMessages(transactionHash: String!): TransactionMessages!
     transactionMessagesCount(colonyAddress: String!): TransactionMessagesCount!
+    subscribedUsers(colonyAddress: String!): [User!]!
   }
 `

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -258,6 +258,22 @@ export type QueryTransactionMessagesCountArgs = {
   colonyAddress: Scalars['String'];
 };
 
+export type Subscription = {
+   __typename?: 'Subscription';
+  transactionMessages: TransactionMessages;
+  transactionMessagesCount: TransactionMessagesCount;
+};
+
+
+export type SubscriptionTransactionMessagesArgs = {
+  transactionHash: Scalars['String'];
+};
+
+
+export type SubscriptionTransactionMessagesCountArgs = {
+  colonyAddress: Scalars['String'];
+};
+
 export enum SuggestionStatus {
   Open = 'Open',
   NotPlanned = 'NotPlanned',
@@ -339,8 +355,12 @@ export type UserProfile = {
 
 
 export enum EventType {
+  AssignWorker = 'AssignWorker',
   CreateDomain = 'CreateDomain',
+  CreateWorkRequest = 'CreateWorkRequest',
   NewUser = 'NewUser',
+  SendWorkInvite = 'SendWorkInvite',
+  UnassignWorker = 'UnassignWorker',
   TransactionMessage = 'TransactionMessage'
 }
 
@@ -448,6 +468,7 @@ export type ResolversTypes = {
   Mutation: ResolverTypeWrapper<{}>,
   ProgramStatus: ProgramStatus,
   Query: ResolverTypeWrapper<{}>,
+  Subscription: ResolverTypeWrapper<{}>,
   SuggestionStatus: SuggestionStatus,
   Suggestion: ResolverTypeWrapper<Suggestion>,
   SystemInfo: ResolverTypeWrapper<SystemInfo>,
@@ -494,6 +515,7 @@ export type ResolversParentTypes = {
   Mutation: {},
   ProgramStatus: ProgramStatus,
   Query: {},
+  Subscription: {},
   SuggestionStatus: SuggestionStatus,
   Suggestion: Suggestion,
   SystemInfo: SystemInfo,
@@ -580,6 +602,11 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   transactionMessagesCount?: Resolver<ResolversTypes['TransactionMessagesCount'], ParentType, ContextType, RequireFields<QueryTransactionMessagesCountArgs, 'colonyAddress'>>,
 };
 
+export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
+  transactionMessages?: SubscriptionResolver<ResolversTypes['TransactionMessages'], "transactionMessages", ParentType, ContextType, RequireFields<SubscriptionTransactionMessagesArgs, 'transactionHash'>>,
+  transactionMessagesCount?: SubscriptionResolver<ResolversTypes['TransactionMessagesCount'], "transactionMessagesCount", ParentType, ContextType, RequireFields<SubscriptionTransactionMessagesCountArgs, 'colonyAddress'>>,
+};
+
 export type SuggestionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Suggestion'] = ResolversParentTypes['Suggestion']> = {
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   createdAt?: Resolver<ResolversTypes['GraphQLDateTime'], ParentType, ContextType>,
@@ -661,6 +688,7 @@ export type Resolvers<ContextType = any> = {
   Notification?: NotificationResolvers<ContextType>,
   Mutation?: MutationResolvers<ContextType>,
   Query?: QueryResolvers<ContextType>,
+  Subscription?: SubscriptionResolvers<ContextType>,
   Suggestion?: SuggestionResolvers<ContextType>,
   SystemInfo?: SystemInfoResolvers<ContextType>,
   TokenInfo?: TokenInfoResolvers<ContextType>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,11 @@ import { json } from 'body-parser'
 import cors from 'cors'
 import { getChallenge, verifyEthSignature } from 'etherpass'
 import { getAddress } from 'ethers/utils'
+import { createServer } from 'http'
 
 config()
 
-import { createApolloServer } from './graphql'
+import { createApolloServer, createSubscriptionServer } from './graphql'
 import { getTokenForAddress } from './auth'
 import { connect } from './db/connect'
 import { provider } from './network/provider'
@@ -42,12 +43,17 @@ const startServer = async () => {
   })
 
   apolloServer.applyMiddleware({ app })
+  const websocketServer = createServer(app)
 
-  app.listen(port, () => {
+  websocketServer.listen(port, () => {
+    createSubscriptionServer(websocketServer, apolloServer.graphqlPath)
     console.log(`Started on port ${port}`)
     if (isDevelopment) {
       console.log(
         `GraphQL at http://localhost:${port}${apolloServer.graphqlPath}`,
+      )
+      console.log(
+        `Subscriptions at ws://localhost:${port}${apolloServer.graphqlPath}`,
       )
     }
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,11 @@
     "outDir": "dist",
     "esModuleInterop": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
   ],
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This PR adds in the initial requirements for supporting subscriptions on the server side:
- websocket server
- subscriptions JWT authentication
- subscription types
- subscription resolvers

Alongside those it adds resolvers for the two subscriptions we need initially:
- `transactionMessages`
- `transactionMessagesCount`
- `subscribedUsers`