### PR TITLE
Add user comment banning functionality

### DIFF
--- a/migrations/02_create_eventBans_collection.js
+++ b/migrations/02_create_eventBans_collection.js
@@ -25,8 +25,17 @@ db.createCollection(
             uniqueItems: true,
             additionalProperties: false,
             items: {
-              bsonType: 'string',
-            }
+              bsonType: 'object',
+              required: ['userAddress', 'eventId'],
+              properties: {
+                userAddress: {
+                  bsonType: 'string',
+                },
+                eventId: {
+                  bsonType: 'objectId',
+                },
+              },
+            },
           }
         }
       }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,8 @@
+export const ROOT_DOMAIN = 1
+
+/*
+ * @TODO Remove and replace with AddressZero from ethers/utils
+ */
 export const ETH_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 /*

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,11 +1,6 @@
 export const ROOT_DOMAIN = 1
 
 /*
- * @TODO Remove and replace with AddressZero from ethers/utils
- */
-export const ETH_ADDRESS = '0x0000000000000000000000000000000000000000'
-
-/*
  * @NOTE Only used for dev purpouses
  */
 export const NETWORK_LOCAL = 'local'

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -536,7 +536,16 @@ export const COLLECTIONS_MANIFEST: CollectionsManifest = new Map([
                 uniqueItems: true,
                 additionalProperties: false,
                 items: {
-                  bsonType: 'string',
+                  bsonType: 'object',
+                  required: ['userAddress', 'eventId'],
+                  properties: {
+                    userAddress: {
+                      bsonType: 'string',
+                    },
+                    eventId: {
+                      bsonType: 'objectId',
+                    },
+                  },
                 },
               },
             } as SchemaFields<EventBansDoc>,

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -1,4 +1,5 @@
 import { CollectionCreateOptions, IndexOptions } from 'mongodb'
+import { AddressZero } from 'ethers/constants'
 import {
   ColonyDoc,
   DomainDoc,
@@ -14,7 +15,6 @@ import {
   TokenDoc,
   UserDoc,
 } from './types'
-import { ETH_ADDRESS } from '../constants'
 
 export enum CollectionNames {
   Colonies = 'colonies',
@@ -762,7 +762,7 @@ export const COLLECTIONS_MANIFEST: CollectionsManifest = new Map([
         {
           name: 'xDai Token',
           symbol: 'XDAI',
-          address: ETH_ADDRESS,
+          address: AddressZero,
           creatorAddress: '',
           decimals: 18,
         },

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -269,11 +269,21 @@ export class ColonyMongoApi {
     return newTransactionMessageId
   }
 
-  async deleteTransactionMessage(initiator: string, id: string) {
+  async deleteTransactionMessage(
+    initiator: string,
+    id: string,
+    adminOverride: boolean = false,
+  ) {
     await this.tryGetUser(initiator)
     const comment = await this.tryGetComment(id)
 
-    // assert.ok(initiator === comment.initiatorAddress || , `User with address '${walletAddress}' not found`)
+    if (!adminOverride) {
+      assert.ok(
+        initiator === comment.initiatorAddress,
+        `User '${initiator}' connot delete a comment they do not own`,
+      )
+    }
+
     const filter: StrictRootQuerySelector<EventDoc<TransactionMessageEvent>> = {
       _id: new ObjectID(id),
     }

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -430,7 +430,7 @@ export class ColonyMongoApi {
      * Update the subscriptions
      */
     this.pubsub.publish(SubscriptionLabel.UserWasBanned, {
-      transactionHash: transactionMessage?.context?.transactionHash,
+      transactionHash: transactionMessage?.context?.transactionHash || '',
       colonyAddress,
     })
 
@@ -471,7 +471,7 @@ export class ColonyMongoApi {
      * Update the subscriptions
      */
     this.pubsub.publish(SubscriptionLabel.UserWasUnBanned, {
-      transactionHash: transactionMessage?.context?.transactionHash,
+      transactionHash: transactionMessage?.context?.transactionHash || '',
       colonyAddress,
     })
 

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -441,14 +441,18 @@ export class ColonyMongoApi {
     initiator: string,
     colonyAddress: string,
     userAddress: string,
+    eventId: string,
   ) {
     await this.tryGetUser(initiator)
-    const { eventId } = await this.tryGetBannedUser(
+    const { eventId: foundEventId } = await this.tryGetBannedUser(
       colonyAddress,
       userAddress,
       false,
     )
-    const transactionMessage = await this.tryGetComment(eventId, false)
+    const transactionMessage = await this.tryGetComment(
+      eventId || foundEventId,
+      false,
+    )
 
     /*
      * Ensure the colony entry always exists (creates a new one if it doesn't)

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -260,6 +260,7 @@ export class ColonyMongoApi {
         message,
         colonyAddress,
         deleted: false,
+        adminDelete: false,
       },
     )
     this.pubsub.publish(SubscriptionLabel.TransactionMessageAdded, {
@@ -288,9 +289,17 @@ export class ColonyMongoApi {
       _id: new ObjectID(id),
     }
 
-    return this.events.updateOne(filter, {
+    let set = {
       $set: { 'context.deleted': true },
-    } as StrictUpdateQuery<EventDoc<TransactionMessageEvent>>)
+    } as StrictUpdateQuery<EventDoc<TransactionMessageEvent>>
+
+    if (adminOverride) {
+      set = {
+        $set: { 'context.adminDelete': true },
+      } as StrictUpdateQuery<EventDoc<TransactionMessageEvent>>
+    }
+
+    return this.events.updateOne(filter, set)
     /*
      * @TODO Don't forget about subscriptions
      */

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -70,9 +70,11 @@ export class ColonyMongoApi {
     return user
   }
 
-  private async tryGetComment(id: string) {
+  private async tryGetComment(id: string, assertive: boolean = true) {
     const eventMessage = await this.events.findOne(ObjectID(id))
-    assert.ok(!!eventMessage, `Comment "${id}" does not exist`)
+    if (assertive) {
+      assert.ok(!!eventMessage, `Comment "${id}" does not exist`)
+    }
     return eventMessage
   }
 
@@ -357,9 +359,7 @@ export class ColonyMongoApi {
     eventId: string,
   ) {
     await this.tryGetUser(initiator)
-    const {
-      context: { transactionHash },
-    } = await this.tryGetComment(eventId)
+    const transactionMessage = await this.tryGetComment(eventId, false)
     await this.tryGetBannedUser(colonyAddress, userAddress)
 
     /*
@@ -390,7 +390,7 @@ export class ColonyMongoApi {
      * Update the subscriptions
      */
     this.pubsub.publish(SubscriptionLabel.UserWasBanned, {
-      transactionHash,
+      transactionHash: transactionMessage?.context?.transactionHash,
       colonyAddress,
     })
 
@@ -408,9 +408,7 @@ export class ColonyMongoApi {
       userAddress,
       false,
     )
-    const {
-      context: { transactionHash },
-    } = await this.tryGetComment(eventId)
+    const transactionMessage = await this.tryGetComment(eventId, false)
 
     /*
      * Ensure the colony entry always exists (creates a new one if it doesn't)
@@ -433,7 +431,7 @@ export class ColonyMongoApi {
      * Update the subscriptions
      */
     this.pubsub.publish(SubscriptionLabel.UserWasUnBanned, {
-      transactionHash,
+      transactionHash: transactionMessage?.context?.transactionHash,
       colonyAddress,
     })
 

--- a/src/db/colonyMongoApi.ts
+++ b/src/db/colonyMongoApi.ts
@@ -276,11 +276,14 @@ export class ColonyMongoApi {
     adminOverride: boolean = false,
   ) {
     await this.tryGetUser(initiator)
-    const comment = await this.tryGetComment(id)
+    const {
+      initiatorAddress,
+      context: { transactionHash, colonyAddress },
+    } = await this.tryGetComment(id)
 
     if (!adminOverride) {
       assert.ok(
-        initiator === comment.initiatorAddress,
+        initiator === initiatorAddress,
         `User '${initiator}' connot delete a comment they do not own`,
       )
     }
@@ -299,9 +302,11 @@ export class ColonyMongoApi {
       } as StrictUpdateQuery<EventDoc<TransactionMessageEvent>>
     }
 
+    this.pubsub.publish(SubscriptionLabel.TransactionMessageDeleted, {
+      transactionHash,
+      colonyAddress,
+    })
+
     return this.events.updateOne(filter, set)
-    /*
-     * @TODO Don't forget about subscriptions
-     */
   }
 }

--- a/src/db/colonyMongoDataSource.ts
+++ b/src/db/colonyMongoDataSource.ts
@@ -113,6 +113,20 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
     }))
   }
 
+  private static transformBannedUser({
+    userAddress,
+    eventId,
+  }: {
+    userAddress: string
+    eventId?: string
+  }) {
+    return {
+      id: userAddress,
+      eventId,
+      banned: true,
+    }
+  }
+
   async getUserByAddress(walletAddress: string, ttl?: number) {
     const query = { walletAddress }
     const [doc] = ttl
@@ -130,6 +144,17 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
       ? await this.collections.users.findManyByQuery(query, { ttl })
       : await this.collections.users.collection.find(query).toArray()
     return docs.map(ColonyMongoDataSource.transformUser)
+  }
+
+  async getEventById(eventId: string, ttl?: number) {
+    const query = { _id: ObjectID(eventId) }
+    const [doc] = ttl
+      ? await this.collections.events.findManyByQuery(query, { ttl })
+      : [await this.collections.events.collection.findOne(query)]
+
+    if (!doc) throw new Error(`Event with id '${eventId}' not found`)
+
+    return ColonyMongoDataSource.transformEvent(doc)
   }
 
   async getColonySubscribedUsers(colonyAddress: string, ttl?: number) {
@@ -244,5 +269,17 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
       ? await this.collections.events.findManyByQuery(query, { ttl })
       : await this.collections.events.collection.find(query).toArray()
     return ColonyMongoDataSource.transformTransactionMessagesCount(events)
+  }
+
+  async getBannedUsers(colonyAddress: string, ttl?: number) {
+    const query = { colonyAddress: colonyAddress }
+    const [bannedUsers] = ttl
+      ? await this.collections.eventBans.findManyByQuery(query, { ttl })
+      : await this.collections.eventBans.collection.find(query).toArray()
+    return (
+      bannedUsers?.bannedWalletAddresses.map(
+        ColonyMongoDataSource.transformBannedUser,
+      ) || []
+    )
   }
 }

--- a/src/db/colonyMongoDataSource.ts
+++ b/src/db/colonyMongoDataSource.ts
@@ -272,7 +272,7 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
   }
 
   async getBannedUsers(colonyAddress: string, ttl?: number) {
-    const query = { colonyAddress: colonyAddress }
+    const query = { colonyAddress }
     const [bannedUsers] = ttl
       ? await this.collections.eventBans.findManyByQuery(query, { ttl })
       : await this.collections.eventBans.collection.find(query).toArray()

--- a/src/db/colonyMongoDataSource.ts
+++ b/src/db/colonyMongoDataSource.ts
@@ -3,12 +3,19 @@ import { MongoDataSource } from 'apollo-datasource-mongo'
 import { CachedCollection } from 'apollo-datasource-mongo/dist/cache'
 import { DataSource, DataSourceConfig } from 'apollo-datasource'
 
-import { EventDoc, NotificationDoc, TokenDoc, UserDoc } from './types'
+import {
+  EventBansDoc,
+  EventDoc,
+  NotificationDoc,
+  TokenDoc,
+  UserDoc,
+} from './types'
 import { CollectionNames } from './collections'
 import { Event, TokenInfo, User, EventType } from '../graphql/types'
 
 interface Collections {
   events: CachedCollection<EventDoc<any>>
+  eventBans: CachedCollection<EventBansDoc>
   notifications: CachedCollection<NotificationDoc>
   tokens: CachedCollection<TokenDoc>
   users: CachedCollection<UserDoc>
@@ -21,6 +28,7 @@ export class ColonyMongoDataSource extends MongoDataSource<Collections, {}>
   constructor(db: Db) {
     super([
       db.collection(CollectionNames.Events),
+      db.collection(CollectionNames.EventBans),
       db.collection(CollectionNames.Notifications),
       db.collection(CollectionNames.Tokens),
       db.collection(CollectionNames.Users),

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -78,7 +78,10 @@ export interface EventDoc<C extends object> extends MongoDoc {
 
 export interface EventBansDoc extends MongoDoc {
   colonyAddress: string
-  bannedWalletAddresses: string[]
+  bannedWalletAddresses: Array<{
+    userAddress: string
+    eventId: string
+  }>
 }
 
 export interface ProgramDoc extends MongoDoc {

--- a/src/graphql/__tests__/apolloServer.test.ts
+++ b/src/graphql/__tests__/apolloServer.test.ts
@@ -9,6 +9,7 @@ import { ColonyMongoApi } from '../../db/colonyMongoApi'
 import { ColonyMongoDataSource } from '../../db/colonyMongoDataSource'
 import { ColonyAuthDataSource } from '../../network/colonyAuthDataSource'
 import Event from '../typeDefs/Event'
+import BannedUser from '../typeDefs/BannedUser'
 import Mutation from '../typeDefs/Mutation'
 import Query from '../typeDefs/Query'
 import TokenInfo from '../typeDefs/TokenInfo'
@@ -28,6 +29,7 @@ jest.mock('../resolvers/auth')
 
 const typeDefs = [
   Event,
+  BannedUser,
   Mutation,
   Query,
   TokenInfo,
@@ -97,6 +99,7 @@ describe('Apollo Server', () => {
     await db.collection(CollectionNames.Colonies).deleteMany({})
     await db.collection(CollectionNames.Domains).deleteMany({})
     await db.collection(CollectionNames.Events).deleteMany({})
+    await db.collection(CollectionNames.EventBans).deleteMany({})
     await db.collection(CollectionNames.Notifications).deleteMany({})
     await db.collection(CollectionNames.Tokens).deleteMany({})
     await db.collection(CollectionNames.Users).deleteMany({})

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -54,7 +54,7 @@ const authenticate = (token: string) => {
   let user
 
   // In dev mode we enable a mode without a token for code generation
-  if (isDevelopment && token === 'codegen') {
+  if (token === 'codegen') {
     user = null
   } else {
     /**

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -54,7 +54,7 @@ const authenticate = (token: string) => {
   let user
 
   // In dev mode we enable a mode without a token for code generation
-  if (token === 'codegen') {
+  if (isDevelopment && token === 'codegen') {
     user = null
   } else {
     /**

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -28,6 +28,7 @@ import User from './typeDefs/User'
 import Transaction from './typeDefs/Transaction'
 import scalars from './typeDefs/scalars'
 import Subscriptions from './typeDefs/Subscriptions'
+import BannedUser from './typeDefs/BannedUser'
 
 const pubSubInstance = new PubSub()
 
@@ -41,6 +42,7 @@ const typeDefs = [
   User,
   scalars,
   Transaction,
+  BannedUser,
 ]
 
 let dataSources = {}

--- a/src/graphql/resolvers/BannedUser.ts
+++ b/src/graphql/resolvers/BannedUser.ts
@@ -1,0 +1,12 @@
+import { ApolloContext } from '../apolloTypes'
+import { BannedUserResolvers } from '../types'
+
+export const BannedUser: BannedUserResolvers<ApolloContext> = {
+  async profile({ id: walletAddress }, input, { dataSources: { data } }) {
+    const user = await data.getUserByAddress(walletAddress)
+    return user.profile
+  },
+  async event({ eventId }, input, { dataSources: { data } }) {
+    return data.getEventById(eventId)
+  },
+}

--- a/src/graphql/resolvers/BannedUser.ts
+++ b/src/graphql/resolvers/BannedUser.ts
@@ -7,6 +7,16 @@ export const BannedUser: BannedUserResolvers<ApolloContext> = {
     return user.profile
   },
   async event({ eventId }, input, { dataSources: { data } }) {
-    return data.getEventById(eventId)
+    let event = null
+    /*
+     * @NOTE This needs to be wrapped inside a try/catch if the user was
+     * banned without a reason, meaning the query won't actually find the event
+     */
+    try {
+      event = await data.getEventById(eventId)
+    } catch (error) {
+      // silent error
+    }
+    return event
   },
 }

--- a/src/graphql/resolvers/Mutation.ts
+++ b/src/graphql/resolvers/Mutation.ts
@@ -1,6 +1,6 @@
 import { ApolloContext } from '../apolloTypes'
 import { MutationResolvers } from '../types'
-import { checkAuth } from './auth'
+import { checkAuth, tryAuth } from './auth'
 
 export const Mutation: MutationResolvers<ApolloContext> = {
   // Users
@@ -59,7 +59,7 @@ export const Mutation: MutationResolvers<ApolloContext> = {
     await api.markAllNotificationsAsRead(userAddress)
     return true
   },
-  // Messages
+  // Messages (Comments)
   async sendTransactionMessage(
     parent,
     { input: { transactionHash, message, colonyAddress } },
@@ -85,6 +85,26 @@ export const Mutation: MutationResolvers<ApolloContext> = {
       }),
     )
     await api.deleteTransactionMessage(userAddress, id, adminOverride)
+    return true
+  },
+  // Messages (Comments) User Banning
+  async banUserTransactionMessages(
+    parent,
+    { input: { colonyAddress, userAddress, eventId } },
+    { userAddress: initiatorAddress, api, dataSources: { data, auth } },
+  ) {
+    await tryAuth(
+      auth.assertCanBanUser({
+        colonyAddress,
+        userAddress: initiatorAddress,
+      }),
+    )
+    await api.banUserTransactionMessages(
+      initiatorAddress,
+      colonyAddress,
+      userAddress,
+      eventId,
+    )
     return true
   },
 }

--- a/src/graphql/resolvers/Mutation.ts
+++ b/src/graphql/resolvers/Mutation.ts
@@ -87,6 +87,20 @@ export const Mutation: MutationResolvers<ApolloContext> = {
     await api.deleteTransactionMessage(userAddress, id, adminOverride)
     return true
   },
+  async undeleteTransactionMessage(
+    parent,
+    { input: { id, colonyAddress } },
+    { userAddress, api, dataSources: { data, auth } },
+  ) {
+    const adminOverride = await checkAuth(
+      auth.assertCanDeleteComment({
+        colonyAddress,
+        userAddress,
+      }),
+    )
+    await api.undeleteTransactionMessage(userAddress, id, adminOverride)
+    return true
+  },
   // Messages (Comments) User Banning
   async banUserTransactionMessages(
     parent,

--- a/src/graphql/resolvers/Mutation.ts
+++ b/src/graphql/resolvers/Mutation.ts
@@ -107,4 +107,22 @@ export const Mutation: MutationResolvers<ApolloContext> = {
     )
     return true
   },
+  async unbanUserTransactionMessages(
+    parent,
+    { input: { colonyAddress, userAddress } },
+    { userAddress: initiatorAddress, api, dataSources: { data, auth } },
+  ) {
+    await tryAuth(
+      auth.assertCanBanUser({
+        colonyAddress,
+        userAddress: initiatorAddress,
+      }),
+    )
+    await api.unbanUserTransactionMessages(
+      initiatorAddress,
+      colonyAddress,
+      userAddress,
+    )
+    return true
+  },
 }

--- a/src/graphql/resolvers/Mutation.ts
+++ b/src/graphql/resolvers/Mutation.ts
@@ -123,7 +123,7 @@ export const Mutation: MutationResolvers<ApolloContext> = {
   },
   async unbanUserTransactionMessages(
     parent,
-    { input: { colonyAddress, userAddress } },
+    { input: { colonyAddress, userAddress, eventId } },
     { userAddress: initiatorAddress, api, dataSources: { data, auth } },
   ) {
     await tryAuth(
@@ -136,6 +136,7 @@ export const Mutation: MutationResolvers<ApolloContext> = {
       initiatorAddress,
       colonyAddress,
       userAddress,
+      eventId,
     )
     return true
   },

--- a/src/graphql/resolvers/Mutation.ts
+++ b/src/graphql/resolvers/Mutation.ts
@@ -72,4 +72,12 @@ export const Mutation: MutationResolvers<ApolloContext> = {
     )
     return true
   },
+  async deleteTransactionMessage(
+    parent,
+    { input: { id } },
+    { userAddress, api, dataSources: { data } },
+  ) {
+    await api.deleteTransactionMessage(userAddress, id)
+    return true
+  },
 }

--- a/src/graphql/resolvers/Mutation.ts
+++ b/src/graphql/resolvers/Mutation.ts
@@ -1,5 +1,6 @@
 import { ApolloContext } from '../apolloTypes'
 import { MutationResolvers } from '../types'
+import { checkAuth } from './auth'
 
 export const Mutation: MutationResolvers<ApolloContext> = {
   // Users
@@ -74,10 +75,16 @@ export const Mutation: MutationResolvers<ApolloContext> = {
   },
   async deleteTransactionMessage(
     parent,
-    { input: { id } },
-    { userAddress, api, dataSources: { data } },
+    { input: { id, colonyAddress } },
+    { userAddress, api, dataSources: { data, auth } },
   ) {
-    await api.deleteTransactionMessage(userAddress, id)
+    const adminOverride = await checkAuth(
+      auth.assertCanDeleteComment({
+        colonyAddress,
+        userAddress,
+      }),
+    )
+    await api.deleteTransactionMessage(userAddress, id, adminOverride)
     return true
   },
 }

--- a/src/graphql/resolvers/Query.ts
+++ b/src/graphql/resolvers/Query.ts
@@ -92,4 +92,11 @@ export const Query: QueryResolvers<ApolloContext> = {
   ) {
     return await getTransactionMessagesCount(colonyAddress, data)
   },
+  async bannedUsers(
+    parent,
+    { colonyAddress }: { colonyAddress: string },
+    { dataSources: { data } },
+  ) {
+    return await data.getBannedUsers(colonyAddress)
+  },
 }

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -38,6 +38,7 @@ export const subscription = (pubsub) => ({
       return pubsub.asyncIterator([
         id,
         SubscriptionLabel.TransactionMessageAdded,
+        SubscriptionLabel.TransactionMessageDeleted,
       ])
     },
   },
@@ -55,6 +56,7 @@ export const subscription = (pubsub) => ({
       return pubsub.asyncIterator([
         id,
         SubscriptionLabel.TransactionMessageAdded,
+        SubscriptionLabel.TransactionMessageDeleted,
       ])
     },
   },
@@ -75,4 +77,4 @@ export const subscription = (pubsub) => ({
       ])
     },
   },
-});
+})

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -39,6 +39,8 @@ export const subscription = (pubsub) => ({
         id,
         SubscriptionLabel.TransactionMessageAdded,
         SubscriptionLabel.TransactionMessageDeleted,
+        SubscriptionLabel.UserWasBanned,
+        SubscriptionLabel.UserWasUnBanned,
       ])
     },
   },
@@ -57,6 +59,8 @@ export const subscription = (pubsub) => ({
         id,
         SubscriptionLabel.TransactionMessageAdded,
         SubscriptionLabel.TransactionMessageDeleted,
+        SubscriptionLabel.UserWasBanned,
+        SubscriptionLabel.UserWasUnBanned,
       ])
     },
   },

--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -38,7 +38,7 @@ export const subscription = (pubsub) => ({
       return pubsub.asyncIterator([
         id,
         SubscriptionLabel.TransactionMessageAdded,
-        SubscriptionLabel.TransactionMessageDeleted,
+        SubscriptionLabel.TransactionMessageUpdated,
         SubscriptionLabel.UserWasBanned,
         SubscriptionLabel.UserWasUnBanned,
       ])
@@ -58,7 +58,7 @@ export const subscription = (pubsub) => ({
       return pubsub.asyncIterator([
         id,
         SubscriptionLabel.TransactionMessageAdded,
-        SubscriptionLabel.TransactionMessageDeleted,
+        SubscriptionLabel.TransactionMessageUpdated,
         SubscriptionLabel.UserWasBanned,
         SubscriptionLabel.UserWasUnBanned,
       ])

--- a/src/graphql/resolvers/User.ts
+++ b/src/graphql/resolvers/User.ts
@@ -1,6 +1,5 @@
 import { ApolloContext } from '../apolloTypes'
 import { UserResolvers } from '../types'
-import { ETH_ADDRESS } from '../../constants'
 
 export const User: UserResolvers<ApolloContext> = {
   async notifications(

--- a/src/graphql/resolvers/auth.ts
+++ b/src/graphql/resolvers/auth.ts
@@ -1,13 +1,19 @@
 import { ForbiddenError } from 'apollo-server-errors'
 
-export const tryAuth = async (promise: Promise<boolean>) => {
+export const checkAuth = async (promise: Promise<boolean>) => {
   let auth = false
 
   try {
     auth = await promise
   } catch (caughtError) {
-    throw new ForbiddenError(caughtError.message || caughtError.toString())
+    throw new Error(caughtError.message || caughtError.toString())
   }
+
+  return auth
+}
+
+export const tryAuth = async (promise: Promise<boolean>) => {
+  const auth = await checkAuth(promise)
 
   if (!auth) {
     throw new ForbiddenError('Not allowed')

--- a/src/graphql/resolvers/index.ts
+++ b/src/graphql/resolvers/index.ts
@@ -6,6 +6,7 @@ import { Query } from './Query'
 import { User } from './User'
 import { Mutation } from './Mutation'
 import { Resolvers } from '../types'
+import { BannedUser } from './BannedUser'
 
 export const resolvers: Resolvers<ApolloContext> = {
   Event,
@@ -15,4 +16,5 @@ export const resolvers: Resolvers<ApolloContext> = {
   User,
   Mutation,
   GraphQLDateTime,
+  BannedUser,
 }

--- a/src/graphql/subscriptionTypes.ts
+++ b/src/graphql/subscriptionTypes.ts
@@ -2,4 +2,6 @@ export enum SubscriptionLabel {
   TransactionMessageAdded = 'TRANSACTION_MESSAGE_ADDED',
   TransactionMessageDeleted = 'TRANSACTION_MESSAGE_DELETED',
   ColonySubscriptionUpdated = 'COLONY_SUBSCRIPTION_UPDATED',
+  UserWasBanned = 'USER_WAS_BANNED',
+  UserWasUnBanned = 'USER_WAS_UNBANNED',
 }

--- a/src/graphql/subscriptionTypes.ts
+++ b/src/graphql/subscriptionTypes.ts
@@ -1,6 +1,6 @@
 export enum SubscriptionLabel {
   TransactionMessageAdded = 'TRANSACTION_MESSAGE_ADDED',
-  TransactionMessageDeleted = 'TRANSACTION_MESSAGE_DELETED',
+  TransactionMessageUpdated = 'TRANSACTION_MESSAGE_UPDATED',
   ColonySubscriptionUpdated = 'COLONY_SUBSCRIPTION_UPDATED',
   UserWasBanned = 'USER_WAS_BANNED',
   UserWasUnBanned = 'USER_WAS_UNBANNED',

--- a/src/graphql/subscriptionTypes.ts
+++ b/src/graphql/subscriptionTypes.ts
@@ -1,4 +1,5 @@
 export enum SubscriptionLabel {
   TransactionMessageAdded = 'TRANSACTION_MESSAGE_ADDED',
+  TransactionMessageDeleted = 'TRANSACTION_MESSAGE_DELETED',
   ColonySubscriptionUpdated = 'COLONY_SUBSCRIPTION_UPDATED',
 }

--- a/src/graphql/typeDefs/BannedUser.ts
+++ b/src/graphql/typeDefs/BannedUser.ts
@@ -1,0 +1,11 @@
+import { gql } from 'apollo-server-express'
+
+export default gql`
+  type BannedUser {
+    id: String! # wallet address
+    profile: UserProfile
+    eventId: String
+    event: Event
+    banned: Boolean!
+  }
+`

--- a/src/graphql/typeDefs/Event.ts
+++ b/src/graphql/typeDefs/Event.ts
@@ -23,6 +23,7 @@ export default gql`
     colonyAddress: String!
     deleted: Boolean
     adminDelete: Boolean
+    userBanned: Boolean
   }
 
   union EventContext =

--- a/src/graphql/typeDefs/Event.ts
+++ b/src/graphql/typeDefs/Event.ts
@@ -22,6 +22,7 @@ export default gql`
     message: String!
     colonyAddress: String!
     deleted: Boolean
+    adminDelete: Boolean
   }
 
   union EventContext =

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -55,6 +55,7 @@ export default gql`
     # Messages
     sendTransactionMessage(input: SendTransactionMessageInput!): Boolean!
     deleteTransactionMessage(input: DeleteTransactionMessageInput!): Boolean!
+    undeleteTransactionMessage(input: DeleteTransactionMessageInput!): Boolean!
     # Banning
     banUserTransactionMessages(input: BanTransactionMessagesInput!): Boolean!
     unbanUserTransactionMessages(

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -46,11 +46,6 @@ export default gql`
     eventId: String
   }
 
-  input UnBanTransactionMessagesInput {
-    colonyAddress: String!
-    userAddress: String!
-  }
-
   type Mutation {
     # Messages
     sendTransactionMessage(input: SendTransactionMessageInput!): Boolean!
@@ -58,9 +53,7 @@ export default gql`
     undeleteTransactionMessage(input: DeleteTransactionMessageInput!): Boolean!
     # Banning
     banUserTransactionMessages(input: BanTransactionMessagesInput!): Boolean!
-    unbanUserTransactionMessages(
-      input: UnBanTransactionMessagesInput!
-    ): Boolean!
+    unbanUserTransactionMessages(input: BanTransactionMessagesInput!): Boolean!
     # Notifications
     markAllNotificationsAsRead: Boolean!
     markNotificationAsRead(input: MarkNotificationAsReadInput!): Boolean!

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -67,6 +67,7 @@ export default gql`
 
   input DeleteTransactionMessageInput {
     id: String!
+    colonyAddress: String!
   }
 
   type Mutation {

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -65,9 +65,14 @@ export default gql`
     colonyAddress: String!
   }
 
+  input DeleteTransactionMessageInput {
+    id: String!
+  }
+
   type Mutation {
     # Messages
     sendTransactionMessage(input: SendTransactionMessageInput!): Boolean!
+    deleteTransactionMessage(input: DeleteTransactionMessageInput!): Boolean!
     # Notifications
     markAllNotificationsAsRead: Boolean!
     markNotificationAsRead(input: MarkNotificationAsReadInput!): Boolean!

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -43,7 +43,7 @@ export default gql`
   input BanTransactionMessagesInput {
     colonyAddress: String!
     userAddress: String!
-    eventId: String!
+    eventId: String
   }
 
   input UnBanTransactionMessagesInput {

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -13,25 +13,6 @@ export default gql`
     website: String
   }
 
-  input CreateWorkRequestInput {
-    id: String!
-  }
-
-  input SendWorkInviteInput {
-    id: String!
-    workerAddress: String!
-  }
-
-  input AssignWorkerInput {
-    id: String!
-    workerAddress: String!
-  }
-
-  input UnassignWorkerInput {
-    id: String!
-    workerAddress: String!
-  }
-
   input SubscribeToColonyInput {
     colonyAddress: String!
   }
@@ -44,19 +25,8 @@ export default gql`
     id: String!
   }
 
-  input EditDomainNameInput {
-    colonyAddress: String!
-    ethDomainId: Int!
-    name: String!
-  }
-
   input SetUserTokensInput {
     tokenAddresses: [String!]!
-  }
-
-  input Payout {
-    amount: String!
-    tokenAddress: String!
   }
 
   input SendTransactionMessageInput {
@@ -70,10 +40,18 @@ export default gql`
     colonyAddress: String!
   }
 
+  input BanTransactionMessagesInput {
+    colonyAddress: String!
+    userAddress: String!
+    eventId: String!
+  }
+
   type Mutation {
     # Messages
     sendTransactionMessage(input: SendTransactionMessageInput!): Boolean!
     deleteTransactionMessage(input: DeleteTransactionMessageInput!): Boolean!
+    # Banning
+    banUserTransactionMessages(input: BanTransactionMessagesInput!): Boolean!
     # Notifications
     markAllNotificationsAsRead: Boolean!
     markNotificationAsRead(input: MarkNotificationAsReadInput!): Boolean!

--- a/src/graphql/typeDefs/Mutation.ts
+++ b/src/graphql/typeDefs/Mutation.ts
@@ -46,12 +46,20 @@ export default gql`
     eventId: String!
   }
 
+  input UnBanTransactionMessagesInput {
+    colonyAddress: String!
+    userAddress: String!
+  }
+
   type Mutation {
     # Messages
     sendTransactionMessage(input: SendTransactionMessageInput!): Boolean!
     deleteTransactionMessage(input: DeleteTransactionMessageInput!): Boolean!
     # Banning
     banUserTransactionMessages(input: BanTransactionMessagesInput!): Boolean!
+    unbanUserTransactionMessages(
+      input: UnBanTransactionMessagesInput!
+    ): Boolean!
     # Notifications
     markAllNotificationsAsRead: Boolean!
     markNotificationAsRead(input: MarkNotificationAsReadInput!): Boolean!

--- a/src/graphql/typeDefs/Query.ts
+++ b/src/graphql/typeDefs/Query.ts
@@ -8,5 +8,6 @@ export default gql`
     systemInfo: SystemInfo!
     transactionMessages(transactionHash: String!): TransactionMessages!
     transactionMessagesCount(colonyAddress: String!): TransactionMessagesCount!
+    bannedUsers(colonyAddress: String!): [BannedUser]!
   }
 `

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -128,9 +128,14 @@ export type SendTransactionMessageInput = {
   colonyAddress: Scalars['String'];
 };
 
+export type DeleteTransactionMessageInput = {
+  id: Scalars['String'];
+};
+
 export type Mutation = {
    __typename?: 'Mutation';
   sendTransactionMessage: Scalars['Boolean'];
+  deleteTransactionMessage: Scalars['Boolean'];
   markAllNotificationsAsRead: Scalars['Boolean'];
   markNotificationAsRead: Scalars['Boolean'];
   createUser?: Maybe<User>;
@@ -143,6 +148,11 @@ export type Mutation = {
 
 export type MutationSendTransactionMessageArgs = {
   input: SendTransactionMessageInput;
+};
+
+
+export type MutationDeleteTransactionMessageArgs = {
+  input: DeleteTransactionMessageInput;
 };
 
 
@@ -405,6 +415,7 @@ export type ResolversTypes = {
   SetUserTokensInput: SetUserTokensInput,
   Payout: Payout,
   SendTransactionMessageInput: SendTransactionMessageInput,
+  DeleteTransactionMessageInput: DeleteTransactionMessageInput,
   Mutation: ResolverTypeWrapper<{}>,
   ProgramStatus: ProgramStatus,
   Query: ResolverTypeWrapper<{}>,
@@ -446,6 +457,7 @@ export type ResolversParentTypes = {
   SetUserTokensInput: SetUserTokensInput,
   Payout: Payout,
   SendTransactionMessageInput: SendTransactionMessageInput,
+  DeleteTransactionMessageInput: DeleteTransactionMessageInput,
   Mutation: {},
   ProgramStatus: ProgramStatus,
   Query: {},
@@ -513,6 +525,7 @@ export type NotificationResolvers<ContextType = any, ParentType extends Resolver
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   sendTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendTransactionMessageArgs, 'input'>>,
+  deleteTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationDeleteTransactionMessageArgs, 'input'>>,
   markAllNotificationsAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>,
   markNotificationAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMarkNotificationAsReadArgs, 'input'>>,
   createUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'input'>>,

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -108,7 +108,7 @@ export type DeleteTransactionMessageInput = {
 export type BanTransactionMessagesInput = {
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
-  eventId: Scalars['String'];
+  eventId?: Maybe<Scalars['String']>;
 };
 
 export type UnBanTransactionMessagesInput = {

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -37,6 +37,7 @@ export type TransactionMessageEvent = {
   colonyAddress: Scalars['String'];
   deleted?: Maybe<Scalars['Boolean']>;
   adminDelete?: Maybe<Scalars['Boolean']>;
+  userBanned?: Maybe<Scalars['Boolean']>;
 };
 
 export type EventContext = CreateDomainEvent | NewUserEvent | TransactionMessageEvent;
@@ -485,6 +486,7 @@ export type TransactionMessageEventResolvers<ContextType = any, ParentType exten
   colonyAddress?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   deleted?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
   adminDelete?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  userBanned?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -129,6 +129,7 @@ export type Mutation = {
    __typename?: 'Mutation';
   sendTransactionMessage: Scalars['Boolean'];
   deleteTransactionMessage: Scalars['Boolean'];
+  undeleteTransactionMessage: Scalars['Boolean'];
   banUserTransactionMessages: Scalars['Boolean'];
   unbanUserTransactionMessages: Scalars['Boolean'];
   markAllNotificationsAsRead: Scalars['Boolean'];
@@ -147,6 +148,11 @@ export type MutationSendTransactionMessageArgs = {
 
 
 export type MutationDeleteTransactionMessageArgs = {
+  input: DeleteTransactionMessageInput;
+};
+
+
+export type MutationUndeleteTransactionMessageArgs = {
   input: DeleteTransactionMessageInput;
 };
 
@@ -542,6 +548,7 @@ export type NotificationResolvers<ContextType = any, ParentType extends Resolver
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   sendTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendTransactionMessageArgs, 'input'>>,
   deleteTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationDeleteTransactionMessageArgs, 'input'>>,
+  undeleteTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationUndeleteTransactionMessageArgs, 'input'>>,
   banUserTransactionMessages?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationBanUserTransactionMessagesArgs, 'input'>>,
   unbanUserTransactionMessages?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationUnbanUserTransactionMessagesArgs, 'input'>>,
   markAllNotificationsAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>,

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -110,11 +110,17 @@ export type BanTransactionMessagesInput = {
   eventId: Scalars['String'];
 };
 
+export type UnBanTransactionMessagesInput = {
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
+};
+
 export type Mutation = {
    __typename?: 'Mutation';
   sendTransactionMessage: Scalars['Boolean'];
   deleteTransactionMessage: Scalars['Boolean'];
   banUserTransactionMessages: Scalars['Boolean'];
+  unbanUserTransactionMessages: Scalars['Boolean'];
   markAllNotificationsAsRead: Scalars['Boolean'];
   markNotificationAsRead: Scalars['Boolean'];
   createUser?: Maybe<User>;
@@ -137,6 +143,11 @@ export type MutationDeleteTransactionMessageArgs = {
 
 export type MutationBanUserTransactionMessagesArgs = {
   input: BanTransactionMessagesInput;
+};
+
+
+export type MutationUnbanUserTransactionMessagesArgs = {
+  input: UnBanTransactionMessagesInput;
 };
 
 
@@ -395,6 +406,7 @@ export type ResolversTypes = {
   SendTransactionMessageInput: SendTransactionMessageInput,
   DeleteTransactionMessageInput: DeleteTransactionMessageInput,
   BanTransactionMessagesInput: BanTransactionMessagesInput,
+  UnBanTransactionMessagesInput: UnBanTransactionMessagesInput,
   Mutation: ResolverTypeWrapper<{}>,
   ProgramStatus: ProgramStatus,
   Query: ResolverTypeWrapper<{}>,
@@ -432,6 +444,7 @@ export type ResolversParentTypes = {
   SendTransactionMessageInput: SendTransactionMessageInput,
   DeleteTransactionMessageInput: DeleteTransactionMessageInput,
   BanTransactionMessagesInput: BanTransactionMessagesInput,
+  UnBanTransactionMessagesInput: UnBanTransactionMessagesInput,
   Mutation: {},
   ProgramStatus: ProgramStatus,
   Query: {},
@@ -502,6 +515,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   sendTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendTransactionMessageArgs, 'input'>>,
   deleteTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationDeleteTransactionMessageArgs, 'input'>>,
   banUserTransactionMessages?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationBanUserTransactionMessagesArgs, 'input'>>,
+  unbanUserTransactionMessages?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationUnbanUserTransactionMessagesArgs, 'input'>>,
   markAllNotificationsAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>,
   markNotificationAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMarkNotificationAsReadArgs, 'input'>>,
   createUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'input'>>,

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -120,11 +120,6 @@ export type BanTransactionMessagesInput = {
   eventId?: Maybe<Scalars['String']>;
 };
 
-export type UnBanTransactionMessagesInput = {
-  colonyAddress: Scalars['String'];
-  userAddress: Scalars['String'];
-};
-
 export type Mutation = {
    __typename?: 'Mutation';
   sendTransactionMessage: Scalars['Boolean'];
@@ -163,7 +158,7 @@ export type MutationBanUserTransactionMessagesArgs = {
 
 
 export type MutationUnbanUserTransactionMessagesArgs = {
-  input: UnBanTransactionMessagesInput;
+  input: BanTransactionMessagesInput;
 };
 
 
@@ -429,7 +424,6 @@ export type ResolversTypes = {
   SendTransactionMessageInput: SendTransactionMessageInput,
   DeleteTransactionMessageInput: DeleteTransactionMessageInput,
   BanTransactionMessagesInput: BanTransactionMessagesInput,
-  UnBanTransactionMessagesInput: UnBanTransactionMessagesInput,
   Mutation: ResolverTypeWrapper<{}>,
   ProgramStatus: ProgramStatus,
   Query: ResolverTypeWrapper<{}>,
@@ -468,7 +462,6 @@ export type ResolversParentTypes = {
   SendTransactionMessageInput: SendTransactionMessageInput,
   DeleteTransactionMessageInput: DeleteTransactionMessageInput,
   BanTransactionMessagesInput: BanTransactionMessagesInput,
-  UnBanTransactionMessagesInput: UnBanTransactionMessagesInput,
   Mutation: {},
   ProgramStatus: ProgramStatus,
   Query: {},

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -130,6 +130,7 @@ export type SendTransactionMessageInput = {
 
 export type DeleteTransactionMessageInput = {
   id: Scalars['String'];
+  colonyAddress: Scalars['String'];
 };
 
 export type Mutation = {

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -77,25 +77,6 @@ export type EditUserInput = {
   website?: Maybe<Scalars['String']>;
 };
 
-export type CreateWorkRequestInput = {
-  id: Scalars['String'];
-};
-
-export type SendWorkInviteInput = {
-  id: Scalars['String'];
-  workerAddress: Scalars['String'];
-};
-
-export type AssignWorkerInput = {
-  id: Scalars['String'];
-  workerAddress: Scalars['String'];
-};
-
-export type UnassignWorkerInput = {
-  id: Scalars['String'];
-  workerAddress: Scalars['String'];
-};
-
 export type SubscribeToColonyInput = {
   colonyAddress: Scalars['String'];
 };
@@ -108,19 +89,8 @@ export type MarkNotificationAsReadInput = {
   id: Scalars['String'];
 };
 
-export type EditDomainNameInput = {
-  colonyAddress: Scalars['String'];
-  ethDomainId: Scalars['Int'];
-  name: Scalars['String'];
-};
-
 export type SetUserTokensInput = {
   tokenAddresses: Array<Scalars['String']>;
-};
-
-export type Payout = {
-  amount: Scalars['String'];
-  tokenAddress: Scalars['String'];
 };
 
 export type SendTransactionMessageInput = {
@@ -134,10 +104,17 @@ export type DeleteTransactionMessageInput = {
   colonyAddress: Scalars['String'];
 };
 
+export type BanTransactionMessagesInput = {
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
+  eventId: Scalars['String'];
+};
+
 export type Mutation = {
    __typename?: 'Mutation';
   sendTransactionMessage: Scalars['Boolean'];
   deleteTransactionMessage: Scalars['Boolean'];
+  banUserTransactionMessages: Scalars['Boolean'];
   markAllNotificationsAsRead: Scalars['Boolean'];
   markNotificationAsRead: Scalars['Boolean'];
   createUser?: Maybe<User>;
@@ -155,6 +132,11 @@ export type MutationSendTransactionMessageArgs = {
 
 export type MutationDeleteTransactionMessageArgs = {
   input: DeleteTransactionMessageInput;
+};
+
+
+export type MutationBanUserTransactionMessagesArgs = {
+  input: BanTransactionMessagesInput;
 };
 
 
@@ -406,18 +388,13 @@ export type ResolversTypes = {
   LevelStatus: LevelStatus,
   CreateUserInput: CreateUserInput,
   EditUserInput: EditUserInput,
-  CreateWorkRequestInput: CreateWorkRequestInput,
-  SendWorkInviteInput: SendWorkInviteInput,
-  AssignWorkerInput: AssignWorkerInput,
-  UnassignWorkerInput: UnassignWorkerInput,
   SubscribeToColonyInput: SubscribeToColonyInput,
   UnsubscribeFromColonyInput: UnsubscribeFromColonyInput,
   MarkNotificationAsReadInput: MarkNotificationAsReadInput,
-  EditDomainNameInput: EditDomainNameInput,
   SetUserTokensInput: SetUserTokensInput,
-  Payout: Payout,
   SendTransactionMessageInput: SendTransactionMessageInput,
   DeleteTransactionMessageInput: DeleteTransactionMessageInput,
+  BanTransactionMessagesInput: BanTransactionMessagesInput,
   Mutation: ResolverTypeWrapper<{}>,
   ProgramStatus: ProgramStatus,
   Query: ResolverTypeWrapper<{}>,
@@ -448,18 +425,13 @@ export type ResolversParentTypes = {
   LevelStatus: LevelStatus,
   CreateUserInput: CreateUserInput,
   EditUserInput: EditUserInput,
-  CreateWorkRequestInput: CreateWorkRequestInput,
-  SendWorkInviteInput: SendWorkInviteInput,
-  AssignWorkerInput: AssignWorkerInput,
-  UnassignWorkerInput: UnassignWorkerInput,
   SubscribeToColonyInput: SubscribeToColonyInput,
   UnsubscribeFromColonyInput: UnsubscribeFromColonyInput,
   MarkNotificationAsReadInput: MarkNotificationAsReadInput,
-  EditDomainNameInput: EditDomainNameInput,
   SetUserTokensInput: SetUserTokensInput,
-  Payout: Payout,
   SendTransactionMessageInput: SendTransactionMessageInput,
   DeleteTransactionMessageInput: DeleteTransactionMessageInput,
+  BanTransactionMessagesInput: BanTransactionMessagesInput,
   Mutation: {},
   ProgramStatus: ProgramStatus,
   Query: {},
@@ -529,6 +501,7 @@ export type NotificationResolvers<ContextType = any, ParentType extends Resolver
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   sendTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendTransactionMessageArgs, 'input'>>,
   deleteTransactionMessage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationDeleteTransactionMessageArgs, 'input'>>,
+  banUserTransactionMessages?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationBanUserTransactionMessagesArgs, 'input'>>,
   markAllNotificationsAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>,
   markNotificationAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMarkNotificationAsReadArgs, 'input'>>,
   createUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'input'>>,

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -12,6 +12,15 @@ export type Scalars = {
   GraphQLDateTime: any;
 };
 
+export type BannedUser = {
+   __typename?: 'BannedUser';
+  id: Scalars['String'];
+  profile?: Maybe<UserProfile>;
+  eventId?: Maybe<Scalars['String']>;
+  event?: Maybe<Event>;
+  banned: Scalars['Boolean'];
+};
+
 export type ColonyEvent = {
   type: EventType;
   colonyAddress?: Maybe<Scalars['String']>;
@@ -195,6 +204,7 @@ export type Query = {
   systemInfo: SystemInfo;
   transactionMessages: TransactionMessages;
   transactionMessagesCount: TransactionMessagesCount;
+  bannedUsers: Array<Maybe<BannedUser>>;
 };
 
 
@@ -219,6 +229,11 @@ export type QueryTransactionMessagesArgs = {
 
 
 export type QueryTransactionMessagesCountArgs = {
+  colonyAddress: Scalars['String'];
+};
+
+
+export type QueryBannedUsersArgs = {
   colonyAddress: Scalars['String'];
 };
 
@@ -389,6 +404,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']>,
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+  BannedUser: ResolverTypeWrapper<BannedUser>,
   ColonyEvent: ResolversTypes['CreateDomainEvent'],
   CreateDomainEvent: ResolverTypeWrapper<CreateDomainEvent>,
   Int: ResolverTypeWrapper<Scalars['Int']>,
@@ -427,6 +443,7 @@ export type ResolversTypes = {
 export type ResolversParentTypes = {
   String: Scalars['String'],
   Boolean: Scalars['Boolean'],
+  BannedUser: BannedUser,
   ColonyEvent: ResolversParentTypes['CreateDomainEvent'],
   CreateDomainEvent: CreateDomainEvent,
   Int: Scalars['Int'],
@@ -459,6 +476,15 @@ export type ResolversParentTypes = {
   UserProfile: UserProfile,
   GraphQLDateTime: Scalars['GraphQLDateTime'],
   EventType: EventType,
+};
+
+export type BannedUserResolvers<ContextType = any, ParentType extends ResolversParentTypes['BannedUser'] = ResolversParentTypes['BannedUser']> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  profile?: Resolver<Maybe<ResolversTypes['UserProfile']>, ParentType, ContextType>,
+  eventId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  event?: Resolver<Maybe<ResolversTypes['Event']>, ParentType, ContextType>,
+  banned?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
 export type ColonyEventResolvers<ContextType = any, ParentType extends ResolversParentTypes['ColonyEvent'] = ResolversParentTypes['ColonyEvent']> = {
@@ -534,6 +560,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   systemInfo?: Resolver<ResolversTypes['SystemInfo'], ParentType, ContextType>,
   transactionMessages?: Resolver<ResolversTypes['TransactionMessages'], ParentType, ContextType, RequireFields<QueryTransactionMessagesArgs, 'transactionHash'>>,
   transactionMessagesCount?: Resolver<ResolversTypes['TransactionMessagesCount'], ParentType, ContextType, RequireFields<QueryTransactionMessagesCountArgs, 'colonyAddress'>>,
+  bannedUsers?: Resolver<Array<Maybe<ResolversTypes['BannedUser']>>, ParentType, ContextType, RequireFields<QueryBannedUsersArgs, 'colonyAddress'>>,
 };
 
 export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
@@ -601,6 +628,7 @@ export interface GraphQlDateTimeScalarConfig extends GraphQLScalarTypeConfig<Res
 }
 
 export type Resolvers<ContextType = any> = {
+  BannedUser?: BannedUserResolvers<ContextType>,
   ColonyEvent?: ColonyEventResolvers,
   CreateDomainEvent?: CreateDomainEventResolvers<ContextType>,
   NewUserEvent?: NewUserEventResolvers<ContextType>,

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -36,6 +36,7 @@ export type TransactionMessageEvent = {
   message: Scalars['String'];
   colonyAddress: Scalars['String'];
   deleted?: Maybe<Scalars['Boolean']>;
+  adminDelete?: Maybe<Scalars['Boolean']>;
 };
 
 export type EventContext = CreateDomainEvent | NewUserEvent | TransactionMessageEvent;
@@ -498,6 +499,7 @@ export type TransactionMessageEventResolvers<ContextType = any, ParentType exten
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   colonyAddress?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   deleted?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  adminDelete?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 

--- a/src/network/colonyAuthDataSource.ts
+++ b/src/network/colonyAuthDataSource.ts
@@ -23,7 +23,8 @@ type UserAddress = string
 type DomainId = number
 
 enum AuthChecks {
-  DeleteComment = 'DeleteComment',
+  DeleteCommentAsAdmin = 'DeleteCommentAsAdmin',
+  BanUser = 'BanUser',
 }
 
 enum AuthTypes {
@@ -44,8 +45,14 @@ interface AuthDeclaration {
 
 const AUTH_DECLARATIONS: Record<AuthChecks, AuthDeclaration> = {
   // Comment
-  DeleteComment: {
-    description: "Delete a user's comment",
+  DeleteCommentAsAdmin: {
+    description: "Delete a user's comment with admin privilesges",
+    roles: [ColonyRoles.Root, ColonyRoles.Administration],
+    type: AuthTypes.Colony,
+  },
+  // User banning / unbanning
+  BanUser: {
+    description: 'Ban a user from commenting on a colony again',
     roles: [ColonyRoles.Root, ColonyRoles.Administration],
     type: AuthTypes.Colony,
   },
@@ -123,6 +130,10 @@ export class ColonyAuthDataSource extends DataSource<any> {
   }
 
   async assertCanDeleteComment(args: ColonyAuthArgs) {
-    return this.assertForColony(AuthChecks.DeleteComment, args)
+    return this.assertForColony(AuthChecks.DeleteCommentAsAdmin, args)
+  }
+
+  async assertCanBanUser(args: ColonyAuthArgs) {
+    return this.assertForColony(AuthChecks.BanUser, args)
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
-import { ETH_ADDRESS, DEFAULT_TOKEN_DECIMALS } from './constants'
+import { AddressZero } from 'ethers/constants'
+import { DEFAULT_TOKEN_DECIMALS } from './constants'
 
 export const isETH = (address: string) =>
-  address === ETH_ADDRESS || address === '0x0'
+  address === AddressZero || address === '0x0'
 
 /*
  * @NOTE Don't trust the incoming decimals


### PR DESCRIPTION
This PR adds in the collection, logic, authentication, queries, subscriptions and migrations required so that `TransactionMessageEvent` type events can be hidden, deleted, or the users creating them be prevented from further commenting on said colony.