### PR TITLE
Add filters for messages and subscribed members subscription

### DIFF
--- a/src/graphql/resolvers/Subscription.ts
+++ b/src/graphql/resolvers/Subscription.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
+import { withFilter } from 'graphql-subscriptions'
 
 import {
   getTransactionMessages,
@@ -27,22 +28,26 @@ export const subscription = (pubsub) => ({
   transactionMessages: {
     resolve: async ({ transactionHash }, args, { dataSources: { data } }) =>
       await getTransactionMessages(transactionHash, data),
-    subscribe: (args, { transactionHash }) => {
-      /*
-       * @NOTE We need a client id to publish the subscription to, otherwise
-       * each new client subscription will reset and re-send all the subscription
-       * data out again
-       */
-      const id = uuidv4()
-      process.nextTick(() => pubsub.publish(id, { transactionHash }))
-      return pubsub.asyncIterator([
-        id,
-        SubscriptionLabel.TransactionMessageAdded,
-        SubscriptionLabel.TransactionMessageUpdated,
-        SubscriptionLabel.UserWasBanned,
-        SubscriptionLabel.UserWasUnBanned,
-      ])
-    },
+    subscribe: withFilter(
+      (args, { transactionHash }) => {
+        /*
+         * @NOTE We need a client id to publish the subscription to, otherwise
+         * each new client subscription will reset and re-send all the subscription
+         * data out again
+         */
+        const id = uuidv4()
+        process.nextTick(() => pubsub.publish(id, { transactionHash }))
+        return pubsub.asyncIterator([
+          id,
+          SubscriptionLabel.TransactionMessageAdded,
+          SubscriptionLabel.TransactionMessageUpdated,
+          SubscriptionLabel.UserWasBanned,
+          SubscriptionLabel.UserWasUnBanned,
+        ])
+      },
+      (payload, variables) =>
+        payload.transactionHash === variables.transactionHash,
+    ),
   },
   transactionMessagesCount: {
     resolve: async ({ colonyAddress }, args, { dataSources: { data } }) =>
@@ -67,18 +72,21 @@ export const subscription = (pubsub) => ({
   subscribedUsers: {
     resolve: async ({ colonyAddress }, args, { dataSources: { data } }) =>
       await getSubscribedUsers(colonyAddress, data),
-    subscribe: (args, { colonyAddress }) => {
-      /*
-       * @NOTE We need a client id to publish the subscription to, otherwise
-       * each new client subscription will reset and re-send all the subscription
-       * data out again
-       */
-      const id = uuidv4()
-      process.nextTick(() => pubsub.publish(id, { colonyAddress }))
-      return pubsub.asyncIterator([
-        id,
-        SubscriptionLabel.ColonySubscriptionUpdated,
-      ])
-    },
+    subscribe: withFilter(
+      (args, { colonyAddress }) => {
+        /*
+         * @NOTE We need a client id to publish the subscription to, otherwise
+         * each new client subscription will reset and re-send all the subscription
+         * data out again
+         */
+        const id = uuidv4()
+        process.nextTick(() => pubsub.publish(id, { colonyAddress }))
+        return pubsub.asyncIterator([
+          id,
+          SubscriptionLabel.ColonySubscriptionUpdated,
+        ])
+      },
+      (payload, variables) => payload.colonyAddress === variables.colonyAddress,
+    ),
   },
 })


### PR DESCRIPTION
Used `withFilter` function inside `transactionMessages` and `subscribedUsers` resolvers in order to avoid both subscriptions from returning data to the wrong colony/chat.

`colonyDapp` side of this PR: https://github.com/JoinColony/colonyDapp/pull/2992