### PR TITLE
Use public submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/colonyNetwork"]
 	path = lib/colonyNetwork
-	url = git@github.com:JoinColony/colonyNetwork.git
+	url = https://github.com/JoinColony/colonyNetwork.git


### PR DESCRIPTION
## Description

- [x] Point submodule to a public repo URL.

**Changes** 🏗

* Change submodule URL to be a public one so that non-team members would be able to checkout and build the project. Currently this triggers an error that remote repository cannot be cloned.
