### PR TITLE
Environment dependent chain native token 

### DIFF
--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -1,5 +1,5 @@
 import { CollectionCreateOptions, IndexOptions } from 'mongodb'
-import { AddressZero } from 'ethers/constants'
+import { blockchainNetwork, addressZeroToken } from '../env'
 import {
   ColonyDoc,
   DomainDoc,
@@ -769,11 +769,11 @@ export const COLLECTIONS_MANIFEST: CollectionsManifest = new Map([
       indexes: [['address', {}]],
       seedDocs: [
         {
-          name: 'xDai Token',
-          symbol: 'XDAI',
-          address: AddressZero,
-          creatorAddress: '',
-          decimals: 18,
+          name: addressZeroToken[blockchainNetwork].name,
+          symbol: addressZeroToken[blockchainNetwork].symbol,
+          address: addressZeroToken[blockchainNetwork].address,
+          creatorAddress: addressZeroToken[blockchainNetwork].creatorAddress,
+          decimals: addressZeroToken[blockchainNetwork].decimals,
         },
       ] as TokenDoc[],
     },

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,3 +1,5 @@
+import { AddressZero } from 'ethers/constants'
+
 export const isDevelopment = process.env.NODE_ENV === 'development'
 export const disableAuthCheck =
   isDevelopment && process.env.DISABLE_AUTH_CHECK === 'true'
@@ -9,3 +11,34 @@ export const isMainnet = blockchainNetwork === 'mainnet'
 export const dbName = process.env.DB_NAME
 export const dbUrl = process.env.DB_URL
 export const rpcUrl = process.env.RPC_URL
+
+export const addressZeroToken = {
+  'local': {
+    name: 'Ethereum',
+    symbol: 'ETH',
+    address: AddressZero,
+    creatorAddress: '',
+    decimals: 18,
+  },
+  'goerli': {
+    name: 'Ethereum',
+    symbol: 'ETH',
+    address: AddressZero,
+    creatorAddress: '',
+    decimals: 18,
+  },
+  'mainnet': {
+    name: 'Ethereum',
+    symbol: 'ETH',
+    address: AddressZero,
+    creatorAddress: '',
+    decimals: 18,
+  },
+  'xdai': {
+    name: 'xDai Token',
+    symbol: 'XDAI',
+    address: AddressZero,
+    creatorAddress: '',
+    decimals: 18,
+  },
+}


### PR DESCRIPTION
## Description

This PR adds in the ability to be able to set the chain's native token (addressZero) to be based on the set network environment variable.

This is not urgent or necessarily required, as it is really only useful in cases where Colony is deployed to a network other then xDai.
