### PR TITLE
Verify JWT Signature

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -30,12 +30,11 @@ export const getAddressFromToken = (token: string) => {
   }
 
   // Verify the JWT signature
-  const res = JWT.verify(token, JWT_KEY, {
+  JWT.verify(token, JWT_KEY, {
     algorithms: ['HS256'],
     audience: 'https://api.colony.io',
     issuer: 'https://colony.io',
   })
-  console.log(res)
 
   return address
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,5 +29,13 @@ export const getAddressFromToken = (token: string) => {
     throw new Error('Authentication token expired')
   }
 
+  // Verify the JWT signature
+  const res = JWT.verify(token, JWT_KEY, {
+    algorithms: ['HS256'],
+    audience: 'https://api.colony.io',
+    issuer: 'https://colony.io',
+  })
+  console.log(res)
+
   return address
 }


### PR DESCRIPTION
This lovely fix was put in by @area after it was discovered that we don't actually verify JWT signatures server side, leaving the door open for anyone with a well crafted request to modify other user's metadata